### PR TITLE
Agency Admin user experience

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,19 @@ For testing in Midas, we are using:
 * [request](https://github.com/mikeal/request) to make http calls for testing API endpoints
 
 The following command will execute a single test file in the application context:
-```NODE_ENV=test ./node_modules/.bin/mocha test/test.upstart.js test/api/sails/tag.test.js```
 
+```
+NODE_ENV=test ./node_modules/.bin/mocha test/test.upstart.js test/api/sails/tag.test.js
+```
+
+Note: there are some methods that use postgres-specific queries.  For ease of development,
+tests for these are marked _pending_. If you are modifying this code, enable these tests
+and make sure they pass.  You will need to have a test database:
+
+```
+psql midas
+CREATE DATABASE midastest WITH TEMPLATE midas;
+```
 
 ### Backbone
 

--- a/api/controllers/AdminController.js
+++ b/api/controllers/AdminController.js
@@ -456,7 +456,6 @@ module.exports = {
   * eg: /api/admin/tasks
   */
   tasks: function ( req, res ) {
-    sails.log.verbose('AdminController tasks', req.allParams())
     var page = parseInt( req.param( 'page', 1 ) ),
       limit = req.param( 'limit', 1000 ),
       sort = req.param( 'sort', 'createdAt desc' ),

--- a/api/controllers/AdminController.js
+++ b/api/controllers/AdminController.js
@@ -477,7 +477,6 @@ module.exports = {
     }
 
     findTasks.then(function(output) {
-      console.log('output ---->', output)
       res.json( output );
     })
     .catch(function(err) {

--- a/api/models/Task.js
+++ b/api/models/Task.js
@@ -204,7 +204,6 @@ module.exports = {
         return Task.byCategoryWithVolunteers(tasks);
       })
       .then(function(output) {
-        console.log('here')
         return output;
       })
     return promise;

--- a/api/models/Task.js
+++ b/api/models/Task.js
@@ -2,6 +2,7 @@
     :: Task
     -> model
 ---------------------*/
+var _ = require('lodash');
 var Promise = require('bluebird');
 var exportUtils = require('../services/utils/export'),
     moment = require('moment');
@@ -188,18 +189,11 @@ module.exports = {
   // draft: [],
   // open: [],
   // submitted: []
-  byCategory: function(page, limit, sort) {
+  byCategory: function(page, limit, sort, domain) {
     var page = page || 1,
       limit = limit || 1000,
-      sort = sort || 'createdAt desc',
-      output = {
-        assigned: [],
-        completed: [],
-        draft: [],
-        open: [],
-        submitted: [],
-      };
-    var tasks, volunteers;
+      sort = sort || 'createdAt desc';
+    var tasks;
     var promise =
       Task.find({ state: [ 'draft', 'submitted', 'open', 'assigned', 'completed' ] })
           .populate('owner')
@@ -207,14 +201,48 @@ module.exports = {
           .paginate({ page: page, limit: limit })
       .then(function(allTasks) {
         tasks = allTasks;
-        volQuery = _.map(tasks, function(t) { return {taskId: t.id} });
-        return Volunteer.findUsersByTask(volQuery)
+        return Task.byCategoryWithVolunteers(tasks);
       })
+      .then(function(output) {
+        console.log('here')
+        return output;
+      })
+    return promise;
+  },
+  // returns a promise to annotate the tasks with their volunteers
+  // and sort into a hash by task state
+  byCategoryWithVolunteers: function(tasks) {
+    var states = [ 'draft', 'submitted', 'open', 'assigned', 'completed' ]
+    var output = {}
+    for (var i in states) {
+      state = states[i]
+      output[state] = [];
+    }
+    sails.log.verbose('output', output);
+
+    var volQuery = _.map(tasks, function(t) { return {taskId: t.id} });
+    var promise =
+      Volunteer.findUsersByTask(volQuery)
       .then(function(taskVolunteers) {
         _.forEach(tasks, function(t) {
-          output[t.state].push(t);
-          t.volunteers = taskVolunteers[t.id] || []
+          if (_.includes(states, t.state)) {
+            sails.log.verbose('output:', t.state, t.title);
+            output[t.state].push(t);
+            t.volunteers = taskVolunteers[t.id] || []
+          }
         })
+        return output;
+      })
+    return promise;
+  },
+  byCategoryForDomain: function(domain) {
+    var promise =
+      Task.findByOwnerDomain(domain)
+      .then(function(allTasks) {
+        tasks = allTasks;
+        return Task.byCategoryWithVolunteers(tasks)
+      })
+      .then(function(output) {
         return output;
       })
     return promise;
@@ -267,6 +295,19 @@ module.exports = {
     });
 
     return promise;
+  },
+
+  // find where owner has username with matching domain
+  // returns a promise
+  findByOwnerDomain: function(domain) {
+    var queryStr = "SELECT task.* from task where \"userId\" " +
+                   "in (SELECT id FROM midas_user WHERE username SIMILAR TO '%(@|.)" +
+                   domain + "')";
+    var taskQuery = Promise.promisify(Task.query, {context: Task});
+    return taskQuery(queryStr).
+    then(function(result) {
+      return result.rows;
+    })
   },
 
   sendNotifications: function(i) {

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -174,6 +174,17 @@ module.exports = {
 
   },
 
+  // returns a promise
+  findByDomain: function(domain) {
+    var queryStr = "SELECT * FROM midas_user WHERE username SIMILAR TO '%(@|.)" +
+                   domain + "'";
+    var userQuery = Promise.promisify(User.query, {context: User});
+    return userQuery(queryStr).
+    then(function(result) {
+      return result.rows;
+    })
+  },
+
   // TODO: add more fields, likely driven off subqueries
   exportFormat: {
     'user_id': 'id',
@@ -190,6 +201,5 @@ module.exports = {
     'admin': 'isAdmin',
     'disabled': 'disabled'
   },
-
 
 };

--- a/api/notifications/comment.create.owner/notification.js
+++ b/api/notifications/comment.create.owner/notification.js
@@ -18,10 +18,7 @@ module.exports = {
       model: {},
       owner: {},
     };
-    console.log('comment.create.owner model:', model);
     User.findOne( { id: model.userId } ).exec( function ( err, commenter ) {
-      console.log('commenter:', commenter);
-
       if ( err ) { return done( err ); }
 
       var Model = ( model.projectId ) ? Project : Task;

--- a/api/policies/admin.js
+++ b/api/policies/admin.js
@@ -1,10 +1,8 @@
 /**
 * Only allow admin to pass through
 */
-
 module.exports = function(req, res, next) {
-  // check if owner of the project or task
-  if (req.user && req.user.isAdmin) {
+  if (req.user && (req.user.isAdmin || req.user.isAgencyAdmin )) {
     return next();
   }
   // Otherwise not allowed.

--- a/api/services/utils/comment.js
+++ b/api/services/utils/comment.js
@@ -19,7 +19,6 @@ var commentAssemble = function (where, done) {
   .sort({'updatedAt':1})
   .exec(function (err, comments) {
     if (err) return done(err, null);
-    console.log('comments', comments);
     var userIds = [];
     for (var i = 0; i < comments.length; i++) {
       if (_.indexOf(userIds, comments[i].userId) == -1) { userIds.push(comments[i].userId); }
@@ -37,8 +36,6 @@ var commentAssemble = function (where, done) {
     async.each(userIds, getId, function (err) {
       if (err) return done(err, null);
       // Attach userIds to topics
-      console.log('users', users);
-      console.log('comments.length', comments.length);
       for (var i = 0; i < comments.length; i++) {
         comments[i].user = { username: users[comments[i].userId].username, name: users[comments[i].userId].name }
       }

--- a/assets/js/backbone/app-run.js
+++ b/assets/js/backbone/app-run.js
@@ -1,6 +1,7 @@
 var _ = require('underscore');
 var Backbone = require('backbone');
 var AppsRouter = require('./apps-router');
+import User from '../utils/user';
 
 var Application = {
   started: null,
@@ -11,7 +12,7 @@ var Application = {
     // Cache user
     // Check if a user is already defined
     if (!_.isUndefined(backendUser)) {
-      window.cache.currentUser = backendUser;
+      window.cache.currentUser = new User(backendUser);
     }
     if (!_.isUndefined(systemName)) {
       window.cache.system.name = systemName;

--- a/assets/js/backbone/apps/admin/controllers/admin_main_controller.js
+++ b/assets/js/backbone/apps/admin/controllers/admin_main_controller.js
@@ -19,6 +19,7 @@ Admin.ShowController = BaseController.extend({
     this.options = options;
     this.adminMainView = new AdminMainView({
       action: options.action,
+      agencyId: options.agencyId,
       el: this.el
     }).render();
   },

--- a/assets/js/backbone/apps/admin/templates/admin_agencies_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_agencies_template.html
@@ -8,7 +8,7 @@
     <div class="row">
       <div class="col-md-12 box-pad-b">
         <h2><%= agency.name %></h2>
-        <p>Domain: <%= agency.data.domain[0] %></p>
+        <p>Domain: <%= agency.data.domain %></p>
         <h3><a class="link" data-target="users" href="/admin/users/<%=agency.slug %>"><%= agency.data.abbr %> Users</a>
           <h3><a class="link" data-target="tasks" href="/admin/tasks/<%=agency.slug %>"><%= agency.data.abbr %> Opportunities</a>
       </div>

--- a/assets/js/backbone/apps/admin/templates/admin_agencies_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_agencies_template.html
@@ -1,11 +1,18 @@
 <div class="alert alert-danger" style="display:none;">
 </div>
 <div class="row">
+  <% if (!agency.data) { %>
+  <p>Agency not set up.</p>
+  <% } else { %>
   <div class="col-md-12 box box-pad-lr">
     <div class="row">
       <div class="col-md-12 box-pad-b">
-        <h2>Coming Soon</h2>
+        <h2><%= agency.name %></h2>
+        <p>Domain: <%= agency.data.domain[0] %></p>
+        <h3><a class="link" data-target="users" href="/admin/users/<%=agency.slug %>"><%= agency.data.abbr %> Users</a>
+          <h3><a class="link" data-target="tasks" href="/admin/tasks/<%=agency.slug %>"><%= agency.data.abbr %> Opportunities</a>
       </div>
     </div>
   </div>
+  <% } %>
 </div>

--- a/assets/js/backbone/apps/admin/templates/admin_main_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_main_template.html
@@ -16,9 +16,9 @@
       <!-- Collect the nav links, forms, and other content for toggling -->
       <div class="collapse navbar-collapse navbar-ex1-collapse">
         <ul class="nav navbar-nav">
-          <li><a href="/admin/agencies" class="link-admin" data-target="agencies">My Agency</a></li>
-          <li><a href="/admin/dashboard" class="link-admin" data-target="dashboard">Dashboard</a></li>
-          <li><a href="/admin/users" class="link-admin" data-target="user">User Management</a></li>
+          <li><a href="/admin/agencies" class="link-admin" data-target="agencies">Agency Dashboard</a></li>
+          <li><a href="/admin/dashboard" class="link-admin dashboard-menu" data-target="dashboard">Dashboard</a></li>
+          <li><a href="/admin/users" class="link-admin" data-target="users">Users</a></li>
           <!-- TODO: li><a href="/admin/tags" class="link-admin" data-target="tag">Tag Configuration</a></li -->
           <li><a href="/admin/tasks" class="link-admin" data-target="tasks">Tasks</a></li>
           <!-- TODO: <li><a href="/admin/participants" class="link-admin" data-target="participants">Participants</a></li> -->

--- a/assets/js/backbone/apps/admin/views/admin_agencies_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_agencies_view.js
@@ -28,10 +28,12 @@ var AdminAgenciesView = Backbone.View.extend({
     $.ajax({
       url: '/api/admin/agency/' + this.data.agency.id,
       dataType: 'json',
-      success: function (data) {
+      success: function (agencyInfo) {
+        agencyInfo.slug = agencyInfo.data.abbr.toLowerCase();
+        agencyInfo.data.domain = agencyInfo.data.domain[0];
         var template = _.template(AdminAgenciesTemplate, {
           variable: 'agency'
-        })(data);
+        })(agencyInfo);
         self.$el.html(template);
       }
     });

--- a/assets/js/backbone/apps/admin/views/admin_agencies_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_agencies_view.js
@@ -17,7 +17,6 @@ var AdminAgenciesView = Backbone.View.extend({
     this.data = {
       agency: window.cache.currentUser.agency
     };
-    console.log('AdminAgenciesView data', this.data.agency);
   },
 
   render: function () {
@@ -42,7 +41,6 @@ var AdminAgenciesView = Backbone.View.extend({
   },
 
   link: function (e) {
-    console.log('link this.data.agency.slug', this.data.agency.slug)
     if (e.preventDefault) e.preventDefault();
     var t = $(e.currentTarget);
     this.adminMainView.routeTarget(t.data('target'), this.data.agency.slug);

--- a/assets/js/backbone/apps/admin/views/admin_agencies_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_agencies_view.js
@@ -8,13 +8,16 @@ var AdminAgenciesTemplate = fs.readFileSync(`${__dirname}/../templates/admin_age
 var AdminAgenciesView = Backbone.View.extend({
 
   events: {
+    'click .link'             : 'link'
   },
 
   initialize: function (options) {
     this.options = options;
+    this.adminMainView = options.adminMainView;
     this.data = {
-      agency: _(window.cache.currentUser.tags).findWhere({ type: 'agency' })
+      agency: window.cache.currentUser.agency
     };
+    console.log('AdminAgenciesView data', this.data.agency);
   },
 
   render: function () {
@@ -22,19 +25,27 @@ var AdminAgenciesView = Backbone.View.extend({
 
     this.$el.show();
 
+    // get meta data for agency
     $.ajax({
       url: '/api/admin/agency/' + this.data.agency.id,
       dataType: 'json',
       success: function (data) {
         var template = _.template(AdminAgenciesTemplate, {
-          variable: 'data'
+          variable: 'agency'
         })(data);
         self.$el.html(template);
       }
     });
 
-    Backbone.history.navigate('/admin/agencies/' + this.data.agency.id);
+    Backbone.history.navigate('/admin/agencies/' + this.data.agency.slug);
     return this;
+  },
+
+  link: function (e) {
+    console.log('link this.data.agency.slug', this.data.agency.slug)
+    if (e.preventDefault) e.preventDefault();
+    var t = $(e.currentTarget);
+    this.adminMainView.routeTarget(t.data('target'), this.data.agency.slug);
   },
 
   cleanup: function () {

--- a/assets/js/backbone/apps/admin/views/admin_main_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_main_view.js
@@ -20,7 +20,6 @@ var AdminMainView = Backbone.View.extend({
   },
 
   initialize: function (options) {
-    console.log('AdminMainView', this.options)
     this.options = options;
   },
 
@@ -47,7 +46,6 @@ var AdminMainView = Backbone.View.extend({
   },
 
   routeTarget: function (target, agencyId) {
-    console.log('routeTarget:', target);
     agencyId = agencyId || this.options.agencyId;
     if (!target) {
       target = 'dashboard';
@@ -63,7 +61,7 @@ var AdminMainView = Backbone.View.extend({
     $($(t.parents('ul')[0]).find('li')).removeClass('active');
     // make the current link active
     $(t.parent('li')[0]).addClass('active');
-    console.log('target', target);
+
     if (target == 'users') {
       if (!this.adminUserView) {
         this.initializeAdminUserView(agencyId);
@@ -118,7 +116,6 @@ var AdminMainView = Backbone.View.extend({
   },
 
   initializeAdminUserView: function (agencyId) {
-    console.log('initializeAdminUserView', agencyId)
     if (this.adminUserView) {
       this.adminUserView.cleanup();
     }
@@ -138,7 +135,6 @@ var AdminMainView = Backbone.View.extend({
   },
 
   initializeAdminTaskView: function (agencyId) {
-    console.log('initializeAdminTaskView', agencyId)
     if (this.adminTaskView) {
       this.adminTaskView.cleanup();
     }
@@ -149,7 +145,6 @@ var AdminMainView = Backbone.View.extend({
   },
 
   initializeAdminAgenciesView: function () {
-    console.log('initializeAdminAgenciesView', this.options.agencyId)
     if (this.adminAgenciesView) {
       this.adminAgenciesView.cleanup();
     }

--- a/assets/js/backbone/apps/admin/views/admin_main_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_main_view.js
@@ -20,6 +20,7 @@ var AdminMainView = Backbone.View.extend({
   },
 
   initialize: function (options) {
+    console.log('AdminMainView', this.options)
     this.options = options;
   },
 
@@ -39,22 +40,33 @@ var AdminMainView = Backbone.View.extend({
     return !!(window.cache.currentUser && window.cache.currentUser.isAgencyAdmin);
   },
 
-  routeTarget: function (target) {
+  userAgencyId: function () {
+    return (window.cache.currentUser
+              && window.cache.currentUser.agency
+              && window.cache.currentUser.agency.slug);
+  },
+
+  routeTarget: function (target, agencyId) {
+    console.log('routeTarget:', target);
+    agencyId = agencyId || this.options.agencyId;
     if (!target) {
       target = 'dashboard';
     }
     // If agency admin, display My Agency page
     if (!this.isAdmin() && this.isAgencyAdmin()) {
-      target = 'agencies';
+      this.hideDashboardMenu();
+      agencyId = this.userAgencyId();   // restrict access to User agency
+      if (target == 'dashboard') target = 'agencies';
     }
     var t = $((this.$("[data-target=" + target + "]"))[0]);
     // remove active classes
     $($(t.parents('ul')[0]).find('li')).removeClass('active');
     // make the current link active
     $(t.parent('li')[0]).addClass('active');
-    if (target == 'user') {
+    console.log('target', target);
+    if (target == 'users') {
       if (!this.adminUserView) {
-        this.initializeAdminUserView();
+        this.initializeAdminUserView(agencyId);
       }
       this.hideOthers();
       this.adminUserView.render();
@@ -66,7 +78,7 @@ var AdminMainView = Backbone.View.extend({
       this.adminTagView.render();
     } else if (target == 'tasks') {
       if (!this.adminTaskView) {
-        this.initializeAdminTaskView();
+        this.initializeAdminTaskView(agencyId);
       }
       this.hideOthers();
       this.adminTaskView.render();
@@ -101,12 +113,18 @@ var AdminMainView = Backbone.View.extend({
     this.$(".admin-container").hide();
   },
 
-  initializeAdminUserView: function () {
+  hideDashboardMenu: function () {
+    this.$(".dashboard-menu").hide();
+  },
+
+  initializeAdminUserView: function (agencyId) {
+    console.log('initializeAdminUserView', agencyId)
     if (this.adminUserView) {
       this.adminUserView.cleanup();
     }
     this.adminUserView = new AdminUserView({
-      el: "#admin-user"
+      el: "#admin-user",
+      agencyId: agencyId
     });
   },
 
@@ -119,21 +137,26 @@ var AdminMainView = Backbone.View.extend({
     });
   },
 
-  initializeAdminTaskView: function () {
+  initializeAdminTaskView: function (agencyId) {
+    console.log('initializeAdminTaskView', agencyId)
     if (this.adminTaskView) {
       this.adminTaskView.cleanup();
     }
     this.adminTaskView = new AdminTaskView({
-      el: "#admin-task"
+      el: "#admin-task",
+      agencyId: agencyId
     });
   },
 
   initializeAdminAgenciesView: function () {
+    console.log('initializeAdminAgenciesView', this.options.agencyId)
     if (this.adminAgenciesView) {
       this.adminAgenciesView.cleanup();
     }
     this.adminAgenciesView = new AdminAgenciesView({
-      el: "#admin-agencies"
+      el: "#admin-agencies",
+      agencyId: this.options.agencyId,
+      adminMainView: this
     });
   },
 

--- a/assets/js/backbone/apps/admin/views/admin_task_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_task_view.js
@@ -26,8 +26,12 @@ var AdminTaskView = Backbone.View.extend({
 
   render: function () {
     var view = this;
+    var url = '/admin/tasks';
+    if (this.options.agencyId) url = url + '/' + this.options.agencyId;
+    Backbone.history.navigate(url);
+
     $.ajax({
-      url: '/api/admin/tasks',
+      url: '/api' + url,
       data: this.data,
       dataType: 'json',
       success: function ( data ) {
@@ -39,7 +43,6 @@ var AdminTaskView = Backbone.View.extend({
       },
     });
 
-    Backbone.history.navigate( '/admin/tasks' );
     return this;
 
   },

--- a/assets/js/backbone/apps/admin/views/admin_user_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_user_view.js
@@ -32,7 +32,6 @@ var AdminUserView = Backbone.View.extend({
   },
 
   initialize: function (options) {
-    console.log('AdminUserView options', options);
     this.options = options;
     this.data = {
       page: 1

--- a/assets/js/backbone/apps/admin/views/admin_user_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_user_view.js
@@ -32,6 +32,7 @@ var AdminUserView = Backbone.View.extend({
   },
 
   initialize: function (options) {
+    console.log('AdminUserView options', options);
     this.options = options;
     this.data = {
       page: 1
@@ -40,7 +41,9 @@ var AdminUserView = Backbone.View.extend({
 
   render: function () {
     var self = this;
-    Backbone.history.navigate('/admin/user');
+    var url = '/admin/users';
+    if (this.options.agencyId) url = url + '/' + this.options.agencyId
+    Backbone.history.navigate(url);
     this.$el.show();
     if (this.rendered === true) {
       return this;
@@ -118,8 +121,11 @@ var AdminUserView = Backbone.View.extend({
 
   fetchData: function (self, data) {
     // perform the ajax request to fetch the user list
+    var url = '/api/admin/users';
+    if (self.options.agencyId) url = url + '/' + self.options.agencyId
+
     $.ajax({
-      url: '/api/admin/users',
+      url: url,
       dataType: 'json',
       data: data,
       success: function (data) {

--- a/assets/js/backbone/browse-app.js
+++ b/assets/js/backbone/browse-app.js
@@ -28,7 +28,7 @@ var BrowseRouter = Backbone.Router.extend({
     'profile/:id(/)'                : 'showProfile',
     'profile/:id(/)/:action'        : 'showProfile',
     'admin(/)'                      : 'showAdmin',
-    'admin(/):action(/)(?:queryStr)': 'showAdmin'
+    'admin(/):action(/)(:agencyId)' : 'showAdmin'
   },
 
   data: { saved: false },
@@ -91,7 +91,6 @@ var BrowseRouter = Backbone.Router.extend({
   },
 
   listTasks: function(queryStr) {
-    console.log("listTasks");
     this.cleanupChildren();
     this.browseListController = new BrowseListController({
       target: 'tasks',
@@ -174,14 +173,12 @@ var BrowseRouter = Backbone.Router.extend({
     this.profileShowController = new ProfileShowController({ id: id, action: action, data: this.data });
   },
 
-  showAdmin: function(action) {
-
+  showAdmin: function(action, agencyId) {
     this.cleanupChildren();
     this.adminMainController = new AdminMainController({
-
       el: '#container',
       action: action,
-
+      agencyId: agencyId
     });
 
   },

--- a/assets/js/utils/user.js
+++ b/assets/js/utils/user.js
@@ -1,0 +1,26 @@
+var _ = require('underscore');
+
+// Wrapper for server User class
+class User {
+  constructor(data) {
+      // initialize with data that comes from server, backendUser or /user/:id
+      // to be compatible with prior usage of raw object
+      for (var i in data) {
+        this[i] = data[i];
+      }
+  }
+  get agency() {
+    var agencyTag = _(this.tags).findWhere({ type: 'agency' });
+
+    // ideally this would be its own object
+    return { id: agencyTag.id,
+             name: agencyTag.name,
+             abbr: agencyTag.data.abbr,
+             domain: agencyTag.data.domain[0],
+             slug: agencyTag.data.abbr.toLowerCase()
+           }
+  }
+
+}
+
+export default User;

--- a/config/connections.js
+++ b/config/connections.js
@@ -51,7 +51,7 @@ module.exports.connections = {
     host        : 'localhost',
     user        : 'midas',
     password    : 'midas',
-    database    : 'midas-test',
+    database    : 'midastest',
   }
 };
 

--- a/config/connections.js
+++ b/config/connections.js
@@ -45,9 +45,16 @@ module.exports.connections = {
     database    : 'midas',
     // populateFast: true  -- removed with sails 0.12.1 upgrade
     // TODO: delete?       -- was this part of soft-delete implementation?
+  },
+  postgresqlTest: {
+    adapter     : 'sails-postgresql',
+    host        : 'localhost',
+    user        : 'midas',
+    password    : 'midas',
+    database    : 'midas-test',
   }
-
 };
+
 
 if (dbURL) {
   module.exports.connections = {

--- a/config/routes.js
+++ b/config/routes.js
@@ -82,6 +82,19 @@ module.exports.routes = {
     controller: 'main',
     action: 'index'
   },
+  '/admin/agencies/:id': {
+    controller: 'main',
+    action: 'index'
+  },
+  '/admin/users/:id': {
+    controller: 'main',
+    action: 'index'
+  },
+  '/admin/tasks/:id': {
+    controller: 'main',
+    action: 'index'
+  },
+
   // '/cron': {
   //   controller: 'main',
   //   action: 'cron'

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -17,12 +17,12 @@ before(function(done) {
     },
     csrf: false,
     connections: {
-      testDB: {
+      defaultTestDB: {
         adapter: 'sails-memory'
       }
     },
     models: {
-      connection: 'testDB'
+      connection: 'defaultTestDB'
     },
     emailProtocol: ''
     // TODO: validateDomains: false,
@@ -31,7 +31,6 @@ before(function(done) {
     // TODO: taskState: 'draft',
     // TODO: draftAdminOnly: false,
   };
-
   sails.lift(config, function(err, server) {
     if (err) return done(err);
     // here you can load fixtures, etc.
@@ -45,8 +44,12 @@ after(function(done) {
 });
 
 beforeEach(function(done) {
-  // Drops database between each test. Also causes all models to be reloaded.
-  // This works because we use the memory database
+  if ( sails.config.models.connection == 'postgresql') {
+    console.log('note: using postgresql connection, not dropping test data');
+  }
+  // When we're using the memory database...
+  // this will drop database between each test.
+  // Also causes all models to be reloaded.
   sails.once('hook:orm:reloaded', done);
   sails.emit('hook:orm:reload');
 });

--- a/test/integration/models/Task.test.js
+++ b/test/integration/models/Task.test.js
@@ -167,14 +167,18 @@ describe('Task model', function() {
 
   });
 
-  // this requires setting up a separate db 'midas-test'
-  // temporarily disabling, since this requires manual setup
+  // this requires setting up a separate db 'midastest' (see CONTRIBUTING.md)
+  // marked 'pending' since this requires manual setup
   xdescribe('#findByOwnerDomain', function() {
     var gsaUsers, otherUsers;
     var gsaTaskOwner;
 
     before(function(done) {
       sails.config.models.connection = 'postgresqlTest'
+      done();
+    })
+    after(function(done) {
+      sails.config.models.connection = 'defaultTestDB'
       done();
     })
     beforeEach(function(done) {

--- a/test/integration/models/Task.test.js
+++ b/test/integration/models/Task.test.js
@@ -1,8 +1,13 @@
+var _ = require('lodash');
+
 var chai = require('chai');
 var assert = chai.assert;
+
+var createUsers = require('./modelUtils').createUsers;
+var createTasks = require('./modelUtils').createTasks;
 var taskFixtures = require('../../fixtures/task');
 var userFixtures = require('../../fixtures/user');
-var _ = require('lodash');
+
 
 describe('Task model', function() {
   var task;
@@ -161,4 +166,52 @@ describe('Task model', function() {
     });
 
   });
+
+  // this requires setting up a separate db 'midas-test'
+  // temporarily disabling, since this requires manual setup
+  xdescribe('#findByOwnerDomain', function() {
+    var gsaUsers, otherUsers;
+    var gsaTaskOwner;
+
+    before(function(done) {
+      sails.config.models.connection = 'postgresqlTest'
+      done();
+    })
+    beforeEach(function(done) {
+      User.destroy({})
+      .then(function() {
+        return Task.destroy({})
+      })
+      .then(function() {
+        return createUsers(2, 'gsa.gov')
+      })
+      .then(function(newUsers) {
+        gsaUsers = newUsers;
+        gsaTaskOwner = gsaUsers[0];
+        return createTasks(2, {owner: gsaTaskOwner});
+      })
+      .then(function(gsaTasks) {
+        return createUsers(4, 'irs.gov')
+      })
+      .then(function(newUsers) {
+        otherUsers = newUsers;
+        return createTasks(3, {owner: otherUsers[0]});
+      })
+      .then(function(irsTasks) {
+        done();
+      })
+      .catch(done);
+    });
+    it('finds only users with given agency', function(done) {
+      Task.findByOwnerDomain('gsa.gov')
+      .then(function(result) {
+        assert.isNotNull(result);
+        assert.equal(result.length, 2);
+        assert.equal(result[0].userId, gsaTaskOwner.id);
+        done()
+      })
+    })
+
+  });
+
 });

--- a/test/integration/models/User.test.js
+++ b/test/integration/models/User.test.js
@@ -171,13 +171,18 @@ describe('UserModel', function() {
     });
 
   });
-  // this requires setting up a separate db 'midas-test'
-  // temporarily disabling, since this requires manual setup
+  // this requires setting up a separate db 'midastest' (see CONTRIBUTING.md)
+  // marked 'pending' since this requires manual setup
   xdescribe('#findByDomain', function() {
     before(function(done) {
       sails.config.models.connection = 'postgresqlTest'
       done();
     })
+    after(function(done) {
+      sails.config.models.connection = 'defaultTestDB'
+      done();
+    })
+
     beforeEach(function(done) {
       User.destroy({})
       .then(function() {

--- a/test/integration/models/User.test.js
+++ b/test/integration/models/User.test.js
@@ -2,6 +2,8 @@ var chai = require('chai');
 var assert = chai.assert;
 chai.use(require('chai-datetime'));
 var users = require('../../fixtures/user');
+var createUsers = require('./modelUtils').createUsers;
+
 
 describe('UserModel', function() {
   var createAttrs, expectedAttrs;
@@ -169,4 +171,42 @@ describe('UserModel', function() {
     });
 
   });
+  // this requires setting up a separate db 'midas-test'
+  // temporarily disabling, since this requires manual setup
+  xdescribe('#findByDomain', function() {
+    before(function(done) {
+      sails.config.models.connection = 'postgresqlTest'
+      done();
+    })
+    beforeEach(function(done) {
+      User.destroy({})
+      .then(function() {
+        return createUsers(10, 'gsa.gov')
+      })
+      .then(function() {
+        // expect that subdomains are found
+        return createUsers(2, 'pbs.gsa.gov')
+      })
+      .then(function() {
+        // this should not be found
+        return createUsers(1, 'fakegsa.gov')
+      })
+      .then(function() {
+        return createUsers(4, 'usda.gov')
+      })
+      .then(function() {
+        done();
+      })
+      .catch(done);
+    });
+    it('finds only users with given agency', function(done) {
+      User.findByDomain('gsa.gov')
+      .then(function(result) {
+        assert.isNotNull(result);
+        assert.equal(result.length, 12);
+        done()
+      })
+    })
+  });
+
 });

--- a/test/integration/models/Volunteer.test.js
+++ b/test/integration/models/Volunteer.test.js
@@ -2,23 +2,7 @@ var assert = require('chai').assert;
 var users = require('../../fixtures/user');
 var sinon = require('sinon');
 var Promise = require('bluebird');
-
-// Reusable utilities
-
-function createUsers(numUsers) {
-  var userAttrs = [];
-
-  for (var i = 0; i < numUsers; i++) {
-    userAttrs.push(
-      {
-        'name': i.toString(),
-        'username': i.toString() + '@gmail.com',
-        'password': 'TestTest123#'
-      }
-    );
-  }
-  return User.create(userAttrs);
-}
+var createUsers = require('./modelUtils').createUsers;
 
 function createVolunteers(users, taskId) {
   // creating 4 volunteers at once, creates 4 badges, not sure why...

--- a/test/integration/models/modelUtils.js
+++ b/test/integration/models/modelUtils.js
@@ -1,0 +1,43 @@
+//
+// helpers for creating models
+//
+var taskFixtures = require('../../fixtures/task');
+
+module.exports = {
+  createUsers: function(numUsers, domain) {
+    var userAttrs = [];
+    domain = domain || "gmail.com"
+
+    for (var i = 0; i < numUsers; i++) {
+      userAttrs.push(
+        {
+          'name': i.toString(),
+          'username': i.toString() + '@' + domain,
+          'password': 'TestTest123#'
+        }
+      );
+    }
+    return User.create(userAttrs);
+  },
+
+  // default owner id is 1
+  // optional: options.owner
+  createTasks: function(numTasks, options) {
+    var attrs = [];
+    var ownerId = 1
+    if (options.owner) ownerId = options.owner.id;
+
+    for (var i = 0; i < numTasks; i++) {
+      attrs.push(
+        {
+          title: 'task ' + i.toString(),
+          state: 'open',
+          userId: ownerId,
+          tags: taskFixtures.oneTimeOpen.tags
+        }
+      );
+    }
+    return Task.create(attrs);
+  }
+
+}

--- a/tools/postgres/addGSAdomain.js
+++ b/tools/postgres/addGSAdomain.js
@@ -1,0 +1,61 @@
+var Sails = require('sails'),
+    _ = require('underscore'),
+    async = require('async');
+
+var opts = {
+  connections: {
+    postgresql: { softDelete: false }
+  }
+};
+
+Sails.lift(opts, function(err, sails) {
+  if (err) return console.error(err);
+
+  function addAgencyDomain (cb) {
+    var agencyName = 'General Services Administration (GSA)';
+    var agencyTag = {
+      type: 'agency',
+      name: agencyName,
+      data: {
+        domain: ['gsa.gov'],
+        abbr: 'GSA'
+      }
+    };
+
+
+    TagEntity.findOne({name: agencyName})
+    .exec(function(err, tagEntity) {
+      if (err) return cb(err);
+      console.log('tagEntity',tagEntity);
+      if (tagEntity) {
+        console.log('Found tag, updating id', tagEntity.id);
+        agencyTag.id = tagEntity.id
+        console.log('update:', agencyTag);
+        TagEntity.update(agencyTag.id, agencyTag)
+        .exec(function(err, result) {
+          console.log('update called (err result)', err, result);
+          if (err) return cb(err);
+          console.log('updated:',result);
+          cb(null);
+        })
+      } else {
+        TagEntity.create(agencyTag)
+        .exec(function(err, result) {
+          if (err) return cb(err);
+          console.log('created:',result);
+          cb(null);
+        })
+      }
+
+    });
+  }
+
+  addAgencyDomain(function(err) {
+    if (err) {
+      console.error('Detail tag addition failed');
+      console.error('Error:', err);
+      return;
+    }
+    console.log('Detail tag addition successful');
+  });
+});


### PR DESCRIPTION
#1299 As a program administrator, I should be able to see all of the users from my agency
#1225 As a program administrator, I should be able to see an admin tasks page for my agency

## Interactive Testing Notes

```
node tools/postgres/addGSAdomain.js
```

in browser, go to : http://localhost:1337/ and make an account with agency GSA
then on the command line

```
psql midas
update midas_user set "isAgencyAdmin"='t' where username='newuser@whatever.com';
```


## Implementation Notes
added agency meta-data (abbr & domain)
/admin/agencies/:abbr
/admin/users/:abbr
/admin/tasks/:abbr

utility script to add meta-data to GSA
  {abbr: "GSA", domain: "gsa.gov"}

agency admin page
use agency abbreviation for slug
- /admin/agencies/:abbr
- display agency meta-data
admin/tasks/:abbr
admin/users/:abbr
- consistent naming for ‘admin/users’ 
  (was admin/user in some places)

create a client-side User object 
- easily access agency data

Server-side
- User.findByDomain
- AdminController users id:gas => filter by gsa.gov

## Automated testing notes
- move createUsers into modelUtils 
- added createTasks to modelUtils
- 2 new tests marked pending, since they require setup 
  - User.findByDomain 
  - Task.findByOwnerDomain

  they use SQL query so require postgres DB  to run them create a new DB midastest and set up with the schema, but no data (added note to CONTRIBUTING.md for how)
