### PR TITLE
Don't render time commitments for full-time details

### DIFF
--- a/assets/js/backbone/apps/tasks/show/templates/task_show_item_template.html
+++ b/assets/js/backbone/apps/tasks/show/templates/task_show_item_template.html
@@ -44,12 +44,16 @@
             </div>
             <h4 class="mb0">Time Commitment</h4>
             <div class="mb2">
-              <% if (madlibTags['task-time-required']) { %>   <!-- One-time, On-going, Full-Time Detail -->
+              <% if (madlibTags['task-time-required']) { %>
+                <!-- One-time, On-going, Full-Time Detail -->
                 <%= madlibTags['task-time-required'][0].name %>
               <% } %>
-              <% if (madlibTags['task-time-estimate']) { %>  <!-- 2-4 hours, etc. -->
+              <% if (madlibTags['task-time-estimate'] &&
+                     <!-- Time commitment should not be shown when the task is a full time detail. -->
+                     !(madlibTags['task-time-required'] && madlibTags['task-time-required'][0].name === 'Full Time Detail')) { %>
                 &mdash;
-                 <%= madlibTags['task-time-estimate'][0].name %> per week
+                <!-- 2-4 hours, etc. -->
+                <%= madlibTags['task-time-estimate'][0].name %> per week
               <% } %>
             </div>
             <% if (model.completedBy) { %>  <!-- estimated completion date -->


### PR DESCRIPTION
*Problem*
See issue #1276 

*Solution*
Add a conditional in the rendering template that checks for whether the required time commitment is full time, and if so doesn't  render the time commitment estimate.

@ultrasaurus Should we not show the ' 'How much time is needed?' option for  when editing full-time detail tasks? I could stick that in this PR too.