### PR TITLE
Add 'Virtual' to tasks with no location tag associated

### DIFF
--- a/assets/js/backbone/apps/browse/templates/task_list_item.html
+++ b/assets/js/backbone/apps/browse/templates/task_list_item.html
@@ -13,8 +13,14 @@
     </div>
 
     <div class="task-list-bottom">
-      <% _.each(tagShow, function (tagType) { %>
+      <% if (!tags["location"]) { %>
+        <div class="task-list-tags c0 task-single-overflow">
+          <i class="task-list-icon-center fa fa-map-marker %>"></i>
+          Virtual
+        </div>
+      <% } %>
 
+      <% _.each(tagShow, function (tagType) { %>
         <% if (tags[tagType]) { %>
         <div class="task-list-tags c0 task-single-overflow">
           <i class="task-list-icon-center <%- tagConfig.tags[tagType].icon %>"></i>


### PR DESCRIPTION
*Problem*

See issue #1293 

*Solution*

Render an entry in the list of info about the task in the browse view clarifying that the task is 'Virtual', ie completable from anywhere