### PR TITLE
show state of checkbox for restricted tasks

### DIFF
--- a/assets/js/backbone/apps/tasks/task-form-view-helper.js
+++ b/assets/js/backbone/apps/tasks/task-form-view-helper.js
@@ -49,7 +49,7 @@ module.exports = {
       timeRequiredTag;
 
     // restrict is a String with agency abbr or empty string for not restricted
-    var isRestricted = !(view.model.get( 'restrict' ) == '')
+    var isRestricted = !(view.model.get( 'restrict' ) === '')
 
     // hide everything by default
     timeRequired.hide();

--- a/assets/js/backbone/apps/tasks/task-form-view-helper.js
+++ b/assets/js/backbone/apps/tasks/task-form-view-helper.js
@@ -2,7 +2,6 @@ var _ = require('underscore');
 
 module.exports = {
   annotateTimeRequired: function(data, userAgency) {
-    console.log('annotateTimeRequired in', data);
     data = _.chain(data).filter(function (item) {
       // if an agency is included in the data of a tag
       // then restrict it to users who are also
@@ -25,7 +24,6 @@ module.exports = {
       }
       return item;
     }).value();
-    console.log('annotateTimeRequired out', data);
 
     return data;
   },
@@ -34,9 +32,7 @@ module.exports = {
    * server if the restrict agency checkbox is checked
    */
   getRestrictAgencyValue: function(view) {
-    var restrictAgencyChecked = view.$( '#task-restrict-agency' ).val();
-    var tmp = restrictAgencyChecked ? view.agency.abbr : '';
-    console.log(tmp, typeof(tmp));
+    var restrictAgencyChecked = view.$( '#task-restrict-agency' ).prop('checked');
     return restrictAgencyChecked ? view.agency.abbr : '';
   },
 
@@ -52,6 +48,9 @@ module.exports = {
       restrictAgency     = view.$('#task-restrict-agency'),
       timeRequiredTag;
 
+    // restrict is a String with agency abbr or empty string for not restricted
+    var isRestricted = !(view.model.get( 'restrict' ) == '')
+
     // hide everything by default
     timeRequired.hide();
     timeRequiredAside.hide();
@@ -62,7 +61,7 @@ module.exports = {
     if (timeRequiredTag) {
       if (view.agency.allowRestrictAgency) {
         restrictAgency.prop('disabled', timeRequiredTag.alwaysRestrictAgency);
-        restrictAgency.prop('checked', (timeRequiredTag.value === 'Full Time Detail'));
+        restrictAgency.prop('checked', (timeRequiredTag.value === 'Full Time Detail') || isRestricted);
       }
 
       if (timeRequiredTag.value === 'One time') {


### PR DESCRIPTION
fix for https://github.com/openopps/openopps-platform/issues/1361

When a task is restricted to a specific agency
the model has the attribute ‘restrict’ 
set to the agency abbr

To test:

1. run the scripts to set GSA agency data:

  ```
  node ./tools/postgres/addGSAdomain.js
  node ./tools/postgres/addGSAFullTimeDetail.js
  ```
2. set your agency to be GSA in your profile

3. Create a new task, under “What type of effort is needed?” you should see a checkbox with label:
  “Limit Participation to GSA Employees”

the state of the checkbox should be saved and display
with the correct state when the task is edited