### PR TITLE
fix for when agency doesn’t have data defined

### DIFF
--- a/assets/js/utils/user.js
+++ b/assets/js/utils/user.js
@@ -15,10 +15,10 @@ class User {
     // ideally this would be its own object
     return { id: agencyTag.id,
              name: agencyTag.name,
-             abbr: agencyTag.data.abbr,
-             domain: agencyTag.data.domain[0],
-             slug: agencyTag.data.abbr.toLowerCase(),
-             allowRestrictAgency: agencyTag.data.allowRestrictAgency
+             abbr: agencyTag.data ? agencyTag.data.abbr : '',
+             domain: agencyTag.data ? agencyTag.data.domain[0] : '',
+             slug: agencyTag.data ? agencyTag.data.abbr.toLowerCase() : '',
+             allowRestrictAgency: agencyTag.data ? agencyTag.data.allowRestrictAgency : false
            }
   }
 

--- a/assets/js/utils/user.js
+++ b/assets/js/utils/user.js
@@ -12,6 +12,8 @@ class User {
   get agency() {
     var agencyTag = _(this.tags).findWhere({ type: 'agency' });
 
+    if (!agencyTag) agencyTag = {};
+
     // ideally this would be its own object
     return { id: agencyTag.id,
              name: agencyTag.name,


### PR DESCRIPTION
This was throwing errors when the database
wasn’t set up special for GSA (and also would
likely have been an issue for other agencies)