### PR TITLE
addresses marked XSS vulnerability

### DIFF
--- a/assets/js/utils/rendererWithExternalLinkSupport.js
+++ b/assets/js/utils/rendererWithExternalLinkSupport.js
@@ -2,6 +2,23 @@ var exports = module.exports = {};
 
 var marked = require('marked');
 var renderer = new marked.Renderer();
+
+function unescape(html) {
+  console.log('html', html)
+	// explicitly match decimal, hex, and named HTML entities
+  return html.replace(/&(#(?:\d+)|(?:#x[0-9A-Fa-f]+)|(\w+))/g, function(_, n) {
+    console.log('found', n);
+    n = n.toLowerCase();
+    if (n === 'colon') return ':';
+    if (n.charAt(0) === '#') {
+      return n.charAt(1) === 'x'
+        ? String.fromCharCode(parseInt(n.substring(2), 16))
+        : String.fromCharCode(+n.substring(1));
+    }
+    return '';
+  });
+}
+
 renderer.link = function(href, title, text) {
   if (this.options.sanitize) {
     try {

--- a/assets/js/utils/rendererWithExternalLinkSupport.js
+++ b/assets/js/utils/rendererWithExternalLinkSupport.js
@@ -4,7 +4,6 @@ var marked = require('marked');
 var renderer = new marked.Renderer();
 
 function unescape(html) {
-  console.log('html', html)
 	// explicitly match decimal, hex, and named HTML entities
   return html.replace(/&(#(?:\d+)|(?:#x[0-9A-Fa-f]+)|(\w+))/g, function(_, n) {
     console.log('found', n);

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "json2csv": "^3.3.0",
     "location": "0.0.1",
     "lodash": "^4.11.2",
-    "marked": "^0.3.5",
+    "marked": "openopps/marked",
     "moment": "^2.12.0",
     "navigator": "^1.0.1",
     "newrelic": "^1.27.2",


### PR DESCRIPTION
our custom linked renderer was created in order to 
render links with blank target (see PR https://github.com/openopps/openopps-platform/pull/1092)
it wasn’t actually calling the marked escape

we made a fork of marked that integrates 2 PRs to resolve XSS issue
then copied the escape function to be used by our custom renderer

here's a [good writeup](https://snyk.io/blog/marked-xss-vulnerability/) with more details about the marked vulnerability