### PR TITLE
check for presence of task-length tag

### DIFF
--- a/assets/js/backbone/apps/tasks/show/templates/task_show_item_template.html
+++ b/assets/js/backbone/apps/tasks/show/templates/task_show_item_template.html
@@ -54,7 +54,7 @@
                 &mdash;
                  <%- madlibTags['task-time-estimate'][0].name %>
               <% } %>
-              <% if (madlibTags['task-time-required'][0].name === "Ongoing") { %>  <!-- 2-4 hours, etc. -->
+              <% if (madlibTags['task-time-required'][0].name === "Ongoing" && madlibTags['task-length']) { %>  <!-- 2-4 hours, etc. -->
                 <%- madlibTags['task-length'][0].name.toLowerCase() %>
               <% } %>
             </div>


### PR DESCRIPTION
should render when task-length tag is missing, 
which is true for some tasks on 18F production/staging

fixes #1380