### PR TITLE
fix for markdown editor buttons

### DIFF
--- a/assets/js/backbone/components/markdown_editor.js
+++ b/assets/js/backbone/components/markdown_editor.js
@@ -20,6 +20,7 @@ var fs = require('fs');
 var $ = require('jquery');
 var _ = require('underscore');
 var Backbone = require('backbone');
+var jqSelection = require('../../vendor/jquery.selection');
 var marked = require('marked');
 var BaseComponent = require('../base/base_component');
 var EditorTemplate = fs.readFileSync(


### PR DESCRIPTION
fixes #1379
not quite sure how we lost this dependency, 
I think this got broken in 0.10.0