### PR TITLE
make it so footer “contact us” is configurable

### DIFF
--- a/assets/js/backbone/apps/footer/templates/footer_template.html
+++ b/assets/js/backbone/apps/footer/templates/footer_template.html
@@ -1,6 +1,8 @@
 <footer class="container center">
+  <% if (ui.contact) { %>
   Questions? Contact us: <a href="<%- ui.contact.link %>" target="_blank"><%- ui.contact.name %></a>
   |
+  <% } %>
   Version <a target="_blank"
   href="<%- versionLink %>"><%- version %></a>
   <% if (login.terms.enabled === true) { %>

--- a/assets/js/backbone/apps/footer/templates/footer_template.html
+++ b/assets/js/backbone/apps/footer/templates/footer_template.html
@@ -1,5 +1,5 @@
 <footer class="container center">
-  <a target="_blank" href="https://github.com/openopps/openopps-platform"><i class="fa fa-github"></i> Powered by open source</a>
+  Questions? Contact us: <a href="<%- ui.contact.link %>" target="_blank"><%- ui.contact.name %></a>
   |
   Version <a target="_blank"
   href="<%- versionLink %>"><%- version %></a>
@@ -10,5 +10,5 @@
   |
   Locations provided by <a target="_blank" href="http://www.geonames.org/">GeoNames</a>
   |
-  Questions? Email us: <a href="mailto:openopps-platform@googlegroups.com" target="_blank">openopps-platform@googlegroups.com</a>
+  <a target="_blank" href="https://github.com/openopps/openopps-platform"><i class="fa fa-github"></i> Powered by open source</a>
 </footer>

--- a/assets/js/backbone/apps/footer/views/footer_view.js
+++ b/assets/js/backbone/apps/footer/views/footer_view.js
@@ -3,6 +3,7 @@ var $ = require('jquery');
 var _ = require('underscore');
 var Backbone = require('backbone');
 var Login = require('../../../config/login.json');
+var UIConfig = require('../../../config/ui.json');
 
 var FooterTemplate = fs.readFileSync(
   __dirname + '/../templates/footer_template.html'
@@ -28,7 +29,8 @@ var FooterView = Backbone.View.extend({
     var data = {
       version: version,
       versionLink: versionLink(version),
-      login: Login
+      login: Login,
+      ui: UIConfig,
     };
     var compiledTemplate = _.template(FooterTemplate)(data);
     this.$el.html(compiledTemplate);

--- a/assets/js/backbone/config/ui.json
+++ b/assets/js/backbone/config/ui.json
@@ -7,6 +7,10 @@
     "url"  : "/faq"
   },
   "systemEmail" : "test@midas.com",
+  "contact": {
+    "name": "openopps-platform group",
+    "link": "https://groups.google.com/forum/#!forum/openopps-platform"
+  },
   "browse": {
     "pageSize" : 27,
     "useInfiniteScroll" : false


### PR DESCRIPTION
also make the default config use http URL rather than mailto for the google group
configuration is in ui.json
```
  "contact": {
    "name": "openopps-platform group",
    "link": "https://groups.google.com/forum/#!forum/openopps-platform"
  },
```
fixes #1384 
