### PR TITLE
run migrate before installing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
   - psql -c "CREATE USER midas WITH PASSWORD 'midas';" -U postgres
   - psql -c "GRANT ALL PRIVILEGES ON DATABASE midas to midas;" -U postgres
   - psql -c "ALTER SCHEMA public OWNER TO midas;" -U postgres
+  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
 before_deploy: npm install -g https://github.com/18F/cf-blue-green/tarball/master
 env:
   global:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,6 +69,7 @@ run the following commands in the interactive terminal (which runs them
 in the Docker machine):
 
 ```
+npm i -g npm@3
 npm install -g node-gyp@3.3.1 grunt-cli@0.1.13
 npm install
 npm run init
@@ -209,6 +210,12 @@ Create database 'midas', user account 'midas' with password 'midas', and assign 
 
 [Node.js](http://nodejs.org/dist/v4.2.2/)
 
+Use npm version 3.x
+
+```
+npm i -g npm@3
+```
+
 #### Install GraphicsMagick
 
 [GraphicsMagick](ftp://ftp.graphicsmagick.org/pub/GraphicsMagick/windows/`)
@@ -253,8 +260,9 @@ also changes configuration.
 
 #### Install openopps node packages (from the openopps git folder)
 
-Then run the normal npm package installer
+Then install npm 3.x and run the normal npm package installer
 
+     npm i -g npm@3
      npm install -g node-gyp@3.3.1 grunt-cli@0.1.13
      npm install
 

--- a/config/session.js
+++ b/config/session.js
@@ -43,8 +43,8 @@ if (redisCreds) {
 } else if (process.env.NODE_ENV !== 'test' && process.env.DATASTORE !== 'local') {
 
   var pgSession = require('connect-pg-simple'),
-      express = require('sails/node_modules/express'),
-      pg = require('sails-postgresql/node_modules/pg'),
+      express = require('express'),
+      pg = require('pg'),
       environment = process.env.NODE_ENV || 'development',
       configs = ['./connections', './env/' + environment, './local'],
       config = {};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "db-migrate": "^0.10.0-beta.11",
     "db-migrate-pg": "^0.1.9",
     "ejs": "2.3.4",
+    "express": "^3.21.2",
     "file-type": "^3.8.0",
     "gm": "^1.22.0",
     "grunt": "0.4.5",
@@ -66,6 +67,7 @@
     "passport-http-bearer": "^1.0.1",
     "passport-local": "^1.0.0",
     "passport-myusa": "^1.0.0",
+    "pg": "4.5.5",
     "pg-promise": "^3.7.5",
     "rc": "1.0.1",
     "request": "^2.69.0",
@@ -97,18 +99,16 @@
     "supertest": "^1.2.0"
   },
   "config": {
-    "grunt": "./node_modules/.bin/grunt",
     "dir": "."
   },
   "scripts": {
     "preinstall": "if [ \"$THEME\" ]; then git clone $THEME _theme; npm run import --openopps-platform:dir=_theme; fi",
     "import": "cp -v $npm_package_config_dir/exclude.txt exclude.txt | true && rsync -av --exclude-from=exclude.txt $npm_package_config_dir/* .",
-    "install-sail-dependencies": "cd node_modules/sails && npm install && cd -",
-    "install": "npm run install-sail-dependencies && npm run uswds && node --version && pwd && ls",
+    "install": "npm run migrate && npm run uswds && node --version && pwd && ls",
     "init": "node ./tools/init.js",
     "demo": "node ./tools/demo.js",
     "build": "npm run browserify",
-    "migrate": "$npm_package_config_grunt db:migrate:up",
+    "migrate": "grunt db:migrate:up",
     "check-migrate": "$npm_package_config_grunt db:migrate:up --dry-run | perl -ne 's/.*Processed migration (.*)/\\x1b[41m[WARNING] Pending Migration: \\1\\x1b[0m (Run `npm run migrate`)/ && print'",
     "start": "npm run build && node app.js",
     "test": "node ./node_modules/mocha/bin/mocha test/bootstrap.test.js test/integration/**/*.test.js",


### PR DESCRIPTION
figured out module dependencies to enable `npm run migrate` as part of `npm install`
this removes a manual step from the deploy when we modify the database
it does require npm version 3.x, so added that to .travis.yml
also updated install instructions, since that is also needed locally