### PR TITLE
Changes for easier deployment to Heroku

### DIFF
--- a/config/connections.js
+++ b/config/connections.js
@@ -1,7 +1,7 @@
 console.log('Loading... ', __filename);
 var cfenv = require('cfenv'),
     appEnv = cfenv.getAppEnv(),
-    dbURL = appEnv.getServiceURL('psql-openopps');
+    dbURL = appEnv.getServiceURL('psql-openopps') || process.env.DATABASE_URL;
 
 /**
  * Connections

--- a/config/session.js
+++ b/config/session.js
@@ -1,6 +1,6 @@
 var cfenv = require('cfenv'),
     appEnv = cfenv.getAppEnv(),
-    dbURL = appEnv.getServiceURL('psql-openopps'),
+    dbURL = appEnv.getServiceURL('psql-openopps') || process.env.DATABASE_URL,
     redisCreds = appEnv.getServiceCreds('redis-openopps');
 
 /**

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "dir": "."
   },
   "scripts": {
-    "preinstall": "if [ \"$THEME\" ]; then git clone $THEME _theme; npm run import --openopps-platform:dir=_theme; fi",
+    "preinstall": "if [ \"$THEME\" ]; then rm -rf _theme; git clone $THEME _theme; npm run import --openopps-platform:dir=_theme; fi",
     "import": "cp -v $npm_package_config_dir/exclude.txt exclude.txt | true && rsync -av --exclude-from=exclude.txt $npm_package_config_dir/* .",
     "install": "npm run migrate && npm run uswds && node --version && pwd && ls",
     "init": "node ./tools/init.js",


### PR DESCRIPTION
Use case: Attempting to deploy the OpenOpps Platform to the Heroku PaaS.

Changes: 
- Assuring that the two places that pull database config from the cfConf fall back to the `DATABASE_URL` in the environment, which is Heroku (and others) preferred method of setting the database.
- Make theming easier to use with Heroku by removing the `_theme` directory on each install.

Testing: Tested locally and on Heroku.