### PR TITLE
Add grunt-cli to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "file-type": "^3.8.0",
     "gm": "^1.22.0",
     "grunt": "0.4.5",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-coffee": "0.13.0",
     "grunt-contrib-concat": "0.5.1",


### PR DESCRIPTION
In my testing, the migration script does not run on install without this.

Tested on a mac, locally, and on heroku.