### PR TITLE
Patch is so that owners can delete participants

### DIFF
--- a/api/policies/ownerOrAdmin.js
+++ b/api/policies/ownerOrAdmin.js
@@ -4,7 +4,9 @@
 
 module.exports = function ownerOrAdmin (req, res, next) {
   // check if owner of the task
-  if (req.isOwner || req.user.isAdmin) {
+  if (req.isOwner ||
+      ( req.body.taskId && req.body.taskId.isOwner ) ||
+      req.user.isAdmin) {
     return next();
   }
   // Otherwise not allowed.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openopps-platform",
   "private": true,
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "platform that creates an empowered network through sharing skills and collaborating on projects",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
Pairing with @EricSchles on this one.

This patch updates the check for isOwner to propagate down to the `req.body.taskId` which doesn't exist on every request for some reason.