### PR TITLE
[ work in progress ] Add custom notifications for agencies

### DIFF
--- a/api/notifications/gsa/badge.create.owner/notification.js
+++ b/api/notifications/gsa/badge.create.owner/notification.js
@@ -1,0 +1,16 @@
+module.exports = {
+
+  subject: 'You earned a new badge',
+
+  to: '<%= user.username %>',
+
+  /*
+  * Prepares the data object to render templates
+  * @param {Notification} notification model
+  * @param {function} callback called with err, data
+  * data.globals defaults to sails.config
+  */
+  data: function(data, done) {
+    done(null, data);
+  }
+};

--- a/api/notifications/gsa/badge.create.owner/template.html
+++ b/api/notifications/gsa/badge.create.owner/template.html
@@ -1,0 +1,11 @@
+<p>Dear <%- user.name %>,</p>
+
+<p>Congratulations on earning the <%- badge.type %> badge!</p>
+
+<p>You are awarded this badge because you <%- badge.description %>.</p>
+
+<p>
+  Thanks!
+  <br/>
+  - The <%- globals.systemName %> Team
+</p>

--- a/api/notifications/gsa/comment.create.owner/notification.js
+++ b/api/notifications/gsa/comment.create.owner/notification.js
@@ -1,0 +1,44 @@
+module.exports = {
+
+  subject: '"<%- model.title %>" has a new comment on <%= globals.systemName %>',
+
+  to: '<%- owner.username %>',
+
+  /*
+  * Prepares the data object to render templates
+  * @param {Notification} notification model
+  * @param {function} callback called with err, data
+  * data.globals defaults to sails.config
+  */
+  data: function( model, done ) {
+
+    var data = {
+      comment: model,
+      commenter: {},
+      model: {},
+      owner: {},
+    };
+    User.findOne( { id: model.userId } ).exec( function ( err, commenter ) {
+      if ( err ) { return done( err ); }
+
+      var Model = ( model.projectId ) ? Project : Task;
+      var modelId = model.projectId || model.taskId;
+
+      // TODO: Does this need two references to the `commenter` object?
+      // Explore how `data` is being used within the Notification template and refactor, maybe.
+      data.owner = data.commenter = commenter;
+
+      Model.findOne( { id: modelId } ).exec( function( err, model ) {
+
+        if ( err ) { return done( err ); }
+
+        data.model = model;
+
+        done( null, data );
+
+      } );
+
+    } );
+
+  },
+};

--- a/api/notifications/gsa/comment.create.owner/template.html
+++ b/api/notifications/gsa/comment.create.owner/template.html
@@ -1,0 +1,18 @@
+<p>Hello<% if (owner.name) { %> <%- owner.name %><% } %>,</p>
+<p>
+<% if (commenter.name) { %>
+<a href="<%- globals.urlPrefix %>/profile/<%- commenter.id %>"><%- commenter.name %></a>
+<% } else { %>Someone<% } %>
+commented in your <% if (comment.projectId) { %>project.<% } else { %>opportunity.<% } %>
+They said:
+<blockquote>
+  <%= comment.value %>
+</blockquote>
+<p class="center full-width">
+  <a href="<%- globals.urlPrefix %>/<% comment.projectId ? print('projects') : print('tasks') %>/<%- model.id%>#comment-<%- comment.id %>" class="btn btn-c2" bgcolor="39B7EA">View Discussion</a>
+</p>
+<p>
+  Thanks!
+  <br/>
+  - The <%- globals.systemName %> Team
+</p>

--- a/api/notifications/gsa/layout.html
+++ b/api/notifications/gsa/layout.html
@@ -1,0 +1,127 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<meta http-equiv="content-type" content="text/html; charset=ISO-8859-1">
+<style type="text/css">
+.wrapper {
+  border-width: 1px;
+  border-color: #c0c0c0;
+  border-radius: 3px;
+  border-style: solid;
+  width: 100%;
+  max-width: 600px;
+  color: #606060;
+  font-size: 18px;
+  margin-left: 10px;
+  margin-right: 10px;
+  font-family: "Helvetica Neue", "Arial", "sans-serif"
+}
+
+.header {
+  border-top-left-radius: 3px;
+  border-top-left-radius: 3px;
+  height: 10px;
+  background-color: #F04F24;
+}
+
+.logo {
+  width: 100%;
+  max-width: 600px;
+  padding: 10px;
+  border-bottom: solid 1px #c0c0c0;
+}
+
+.content {
+  padding: 10px;
+  width: 100%;
+  max-width: 600px;
+}
+.content a {
+  color: #606060;
+}
+.center {
+  text-align: center;
+}
+.full-width {
+  width: 100%;
+  max-width: 600px;
+}
+
+blockquote {
+  border-left: solid 3px #c0c0c0;
+  color: #909090;
+  margin-left: 6px;
+  margin-bottom: 10px;
+  padding: 10px 0 10px 20px;
+}
+
+.btn {
+  padding: 10px;
+  text-decoration: none;
+  border: solid 1px #c0c0c0;
+  border-radius: 8px;
+}
+.btn-c1 {
+  background-color: #F04F24;
+  color: #fff;
+}
+.content a.btn-c2,
+a.btn-c2,
+.btn-c2 {
+  border-color: #297BB5;
+  background-color: #39B7EA;
+  color: #fff;
+  font-weight: bold;
+}
+.btn-lg {
+  font-size: 24px;
+  padding: 15px;
+}
+
+.footer {
+  width: 100%;
+  max-width: 600px;
+  background-color: #f0f0f0;
+  color: #808080;
+  padding: 10px;
+  font-size: 12px;
+}
+.footer a,
+.footer a:link,
+.footer a:active,
+.footer a:visited {
+  color: #606060;
+}
+.footer a:hover {
+  color: #000000;
+}
+</style>
+</head>
+<body bgcolor="#ffffff" text="#000000">
+
+  <table class="wrapper" width="100%" cellpadding="0" cellspacing="0">
+    <tr>
+      <td class="header" bgcolor="F04F24" height="10" width="100%">
+      </td>
+    </tr>
+    <tr>
+      <td class="logo">
+        <img src="<%- globals.urlPrefix %>/images/logo.png" alt="<%- globals.systemName %>"/>
+      </td>
+    </tr>
+    <tr>
+      <td width="100%" class="content">
+        <%= _content %>
+      </td>
+    </tr>
+    <tr>
+      <td width="100%" class="footer" bgcolor="F0F0F0">
+        <p>
+        You received this email because you signed up for <a href="<%- globals.urlPrefix %>"><%- globals.systemName %></a>.
+        </p>
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/api/notifications/gsa/task.create.draft/notification.js
+++ b/api/notifications/gsa/task.create.draft/notification.js
@@ -1,0 +1,27 @@
+module.exports = {
+
+  subject: 'New Open Opportunity Draft Created',
+
+  to: '<%= user.username %>',
+
+  /*
+  * Prepares the data object to render templates
+  * @param {Notification} notification model
+  * @param {function} callback called with err, data
+  * data.globals defaults to sails.config
+  */
+  data: function ( model, done ) {
+    var data = {
+      task: model,
+      user: {},
+    };
+    sails.log.verbose('task.create.draft', model);
+    User.findOne( { id: model.owner } ).exec( function ( err, user ) {
+      if ( err ) return done( err );
+      data.user = user;
+      done( null, data );
+    } );
+
+  },
+
+};

--- a/api/notifications/gsa/task.create.draft/template.html
+++ b/api/notifications/gsa/task.create.draft/template.html
@@ -1,0 +1,13 @@
+<p>Dear <%- user.name %>,</p>
+
+<p>Thank you for drafting an open opportunity.</p>
+
+<p>Your draft can be found <a href="<%- globals.urlPrefix %>/profile/<%- user.id %>">in your profile under Drafts</a>.<p>
+
+<p>For your reference, here's a link to the opportunity: <a href="<%- globals.urlPrefix %>/tasks/<%- task.id %>"><%- task.title %></a></p>
+
+<p>
+  Thanks!
+  <br/>
+  - The <%- globals.systemName %> Team
+</p>

--- a/api/notifications/gsa/task.create.thanks/notification.js
+++ b/api/notifications/gsa/task.create.thanks/notification.js
@@ -1,0 +1,24 @@
+module.exports = {
+
+  subject: 'New Opportunity Submission',
+
+  to: '<%= user.username %>',
+
+  /*
+  * Prepares the data object to render templates
+  * @param {Notification} notification model
+  * @param {function} callback called with err, data
+  * data.globals defaults to sails.config
+  */
+  data: function(model, done) {
+    var data = {
+          task: model,
+          user: {}
+        };
+    User.findOne( { id: model.owner } ).exec( function ( err, user ) {
+      if (err) return done(err);
+      data.user = user;
+      done(null, data);
+    });
+  }
+};

--- a/api/notifications/gsa/task.create.thanks/template.html
+++ b/api/notifications/gsa/task.create.thanks/template.html
@@ -1,0 +1,13 @@
+<p>Dear <%- user.name %>,</p>
+
+<p>Thank you for submitting an open opportunity.</p>
+
+<p>For your reference, here's a link the opportunity: <a href="<%- globals.urlPrefix %>/tasks/<%- task.id %>"><%- task.title %></a></p>
+
+<p>You will be notified when your task has been approved and when people sign up.</p>
+
+<p>
+  Thanks!
+  <br/>
+  - The <%- globals.systemName %> Team
+</p>

--- a/api/notifications/gsa/task.due.soon/notification.js
+++ b/api/notifications/gsa/task.due.soon/notification.js
@@ -1,0 +1,38 @@
+module.exports = {
+
+  subject: '<%- task.title %> is due soon',
+
+  to: '<%- volunteers %>',
+
+  cc: '<%- owner.username %>',
+
+  /*
+  * Prepares the data object to render templates
+  * @param {Notification} notification model
+  * @param {function} callback called with err, data
+  * data.globals defaults to sails.config
+  */
+  data: function(model, done) {
+    var data = {
+          task: model,
+          owner: {},
+          volunteers: ''
+        };
+    User.findOne( { id: model.owner } ).exec( function ( err, owner ) {
+      if (err) return done(err);
+      data.owner = owner;
+
+      Volunteer.find({ taskId: model.id }).exec(function(err, volunteers) {
+        if (err) return done(err);
+        var userIDs = _.pluck(volunteers, 'userId');
+
+        User.find({ id: userIDs }).exec(function(err, users) {
+          data.volunteers = _.pluck(users, 'username').join(', ');
+          done(null, data);
+        });
+
+      });
+
+    });
+  }
+};

--- a/api/notifications/gsa/task.due.soon/template.html
+++ b/api/notifications/gsa/task.due.soon/template.html
@@ -1,0 +1,11 @@
+<p>We noticed that “<a href="<%- globals.urlPrefix %>/tasks/<%- task.id %>"><%- task.title %></a>,” is due in a few days.</p>
+
+<p>How is it going? If you have any questions about completing this opportunity, feel free to reach out to the opportunity creator, <%- owner.name %>, (CC’d on this email).</p>
+
+<p>Thanks for your participation in <%- globals.systemName %>!</p>
+
+<p>
+  Best,
+  <br>
+  The <%- globals.systemName %> Team
+</p>

--- a/api/notifications/gsa/task.due.today/notification.js
+++ b/api/notifications/gsa/task.due.today/notification.js
@@ -1,0 +1,38 @@
+module.exports = {
+
+  subject: '<%- task.title %> is due today',
+
+  to: '<%- volunteers %>',
+
+  cc: '<%- owner.username %>',
+
+  /*
+  * Prepares the data object to render templates
+  * @param {Notification} notification model
+  * @param {function} callback called with err, data
+  * data.globals defaults to sails.config
+  */
+  data: function(model, done) {
+    var data = {
+          task: model,
+          owner: {},
+          volunteers: ''
+        };
+    User.findOne( { id: model.owner } ).exec( function ( err, owner ) {
+      if (err) return done(err);
+      data.owner = owner;
+
+      Volunteer.find({ taskId: model.id }).exec(function(err, volunteers) {
+        if (err) return done(err);
+        var userIDs = _.pluck(volunteers, 'userId');
+
+        User.find({ id: userIDs }).exec(function(err, users) {
+          data.volunteers = _.pluck(users, 'username').join(', ');
+          done(null, data);
+        });
+
+      });
+
+    });
+  }
+};

--- a/api/notifications/gsa/task.due.today/template.html
+++ b/api/notifications/gsa/task.due.today/template.html
@@ -1,0 +1,11 @@
+<p>We noticed “<a href="<%- globals.urlPrefix %>/tasks/<%- task.id %>"><%- task.title %></a>,” isn’t marked completed and wanted to check in on your progress – how’s it going?</p>
+
+<p>If you’re still working on this opportunity, please email <%- owner.name %> (CC’d on this email).</p>
+
+<p>As always, thanks for your participation in <%- globals.systemName %>.</p>
+
+<p>
+  Best,
+  <br>
+  The <%- globals.systemName %> Team
+</p>

--- a/api/notifications/gsa/task.update.assigned/notification.js
+++ b/api/notifications/gsa/task.update.assigned/notification.js
@@ -1,0 +1,38 @@
+module.exports = {
+
+  subject: 'You’ve been selected for <%- task.title %>!',
+
+  to: '<%- volunteers %>',
+
+  cc: '<%- owner.username %>',
+
+  /*
+  * Prepares the data object to render templates
+  * @param {Notification} notification model
+  * @param {function} callback called with err, data
+  * data.globals defaults to sails.config
+  */
+  data: function(model, done) {
+    var data = {
+          task: model,
+          owner: {},
+          volunteers: ''
+        };
+    User.findOne( { id: model.owner } ).exec( function ( err, owner ) {
+      if (err) return done(err);
+      data.owner = owner;
+
+      Volunteer.find({ taskId: model.id }).exec(function(err, volunteers) {
+        if (err) return done(err);
+        var userIDs = _.pluck(volunteers, 'userId');
+
+        User.find({ id: userIDs }).exec(function(err, users) {
+          data.volunteers = _.pluck(users, 'username').join(', ');
+          done(null, data);
+        });
+
+      });
+
+    });
+  }
+};

--- a/api/notifications/gsa/task.update.assigned/template.html
+++ b/api/notifications/gsa/task.update.assigned/template.html
@@ -1,0 +1,15 @@
+<p>Great news: You’ve been selected to complete “<%- task.title %>!”</p>
+
+<p>Before you get started, please review the Opportunity details: <%- globals.urlPrefix %>/tasks/<%- task.id %></p>
+
+<p>Have questions about what you need to do? Post them to the discussion — directly below the Opportunity description — for the quickest response.</p>
+
+<p>If you’d like more in-depth guidance, feel free to reach out to the Opportunity Creator (CC’d on this email) to set up a phone call or video chat.</p>
+
+<p>Thanks again for joining us: We’re excited to have you on the team!</p>
+
+<p>
+  Best,
+  <br>
+  The <%- globals.systemName %> Team
+</p>

--- a/api/notifications/gsa/task.update.completed/notification.js
+++ b/api/notifications/gsa/task.update.completed/notification.js
@@ -1,0 +1,39 @@
+module.exports = {
+
+  subject: '<%- task.title %> is complete — thank you!',
+
+  to: '<%- volunteers %>',
+
+  cc: '<%- owner.username %>',
+
+  /*
+  * Prepares the data object to render templates
+  * @param {Notification} notification model
+  * @param {function} callback called with err, data
+  * data.globals defaults to sails.config
+  */
+  data: function(model, done) {
+    var data = {
+          task: model,
+          owner: {},
+          volunteers: '',
+          survey: sails.config.survey
+        };
+    User.findOne( { id: model.owner } ).exec( function ( err, owner ) {
+      if (err) return done(err);
+      data.owner = owner;
+
+      Volunteer.find({ taskId: model.id }).exec(function(err, volunteers) {
+        if (err) return done(err);
+        var userIDs = _.pluck(volunteers, 'userId');
+
+        User.find({ id: userIDs }).exec(function(err, users) {
+          data.volunteers = _.pluck(users, 'username').join(', ');
+          done(null, data);
+        });
+
+      });
+
+    });
+  }
+};

--- a/api/notifications/gsa/task.update.completed/template.html
+++ b/api/notifications/gsa/task.update.completed/template.html
@@ -1,0 +1,11 @@
+<p>Congrats! You’ve successfully completed “<a href="<%- globals.urlPrefix %>/tasks/<%- task.id %>"><%- task.title %></a>.” Your profile has been updated to reflect your achievement.</p>
+
+<% if (survey) { %>
+<p>We at <%- globals.systemName %> are always looking for ways to make our program better. Please take a moment to complete this quick survey — your feedback will help us continue to improve your experience: <%- survey %></p>
+<% } %>
+
+<p>
+  Thanks again,
+  <br>
+  The <%- globals.systemName %> Team
+</p>

--- a/api/notifications/gsa/task.update.opened/notification.js
+++ b/api/notifications/gsa/task.update.opened/notification.js
@@ -1,0 +1,24 @@
+module.exports = {
+
+  subject: '<%- task.title %> is open!',
+
+  to: '<%= user.username %>',
+
+  /*
+  * Prepares the data object to render templates
+  * @param {Notification} notification model
+  * @param {function} callback called with err, data
+  * data.globals defaults to sails.config
+  */
+  data: function (model, done) {
+    var data = {
+      task: model,
+      user: {},
+    };
+    User.findOne( { id: model.owner } ).exec( function ( err, user ) {
+      if (err) return done(err);
+      data.user = user;
+      done(null, data);
+    });
+  },
+};

--- a/api/notifications/gsa/task.update.opened/template.html
+++ b/api/notifications/gsa/task.update.opened/template.html
@@ -1,0 +1,13 @@
+<p>Dear <%- user.name %>,</p>
+
+<p>Your opportunity, "<a href="<%- globals.urlPrefix %>/tasks/<%- task.id %>"><%- task.title %></a>," is now open.</p>
+
+<p>You will receive a notification each time someone signs up to participate in this opportuntity.</p>
+
+<p>Your opportunity will remain open for applications until either (1) you assign the opportunity to one or more applicants or (2) you archive the opportunity in the system.</p>
+
+<p>
+  Thanks!
+  <br/>
+  - The <%- globals.systemName %> Team
+</p>

--- a/api/notifications/gsa/task.update.submitted/notification.js
+++ b/api/notifications/gsa/task.update.submitted/notification.js
@@ -1,0 +1,26 @@
+module.exports = {
+
+  subject: 'New Open Opportunity Draft Submitted',
+
+  to: '<%= user.username %>',
+
+  /*
+  * Prepares the data object to render templates
+  * @param {Notification} notification model
+  * @param {function} callback called with err, data
+  * data.globals defaults to sails.config
+  */
+  data: function ( model, done ) {
+    var data = {
+      task: model,
+      user: {},
+    };
+    User.findOne( { id: model.owner } ).exec( function ( err, user ) {
+      if ( err ) return done( err );
+      data.user = user;
+      done( null, data );
+    } );
+
+  },
+
+};

--- a/api/notifications/gsa/task.update.submitted/template.html
+++ b/api/notifications/gsa/task.update.submitted/template.html
@@ -1,0 +1,15 @@
+<p>Dear <%- user.name %></p>
+
+<p>Thank you for drafting an open opportunity.</p>
+
+<p>Your draft can be found <a href="<%- globals.urlPrefix %>/profile/<%- user.id %>">in your profile under Drafts</a>.<p>
+
+<p>For your reference, here's a link the opportunity: <a href="<%- globals.urlPrefix %>/tasks/<%- task.id %>"><%- task.title %></a></p>
+
+<p>You will be notified when someone signs up.</p>
+
+<p>
+  Best,
+  <br>
+  The <%- globals.systemName %> Team
+</p>

--- a/api/notifications/gsa/user.create.welcome/notification.js
+++ b/api/notifications/gsa/user.create.welcome/notification.js
@@ -1,0 +1,17 @@
+module.exports = {
+
+  subject: 'Welcome to <%= globals.systemName %>',
+
+  to: '<%= user.username %>',
+
+  /*
+  * Prepares the data object to render templates
+  * @param {Notification} notification model
+  * @param {function} callback called with err, data
+  * data.globals defaults to sails.config
+  */
+  data: function(model, done) {
+    var data = { user: model };
+    done(null, data);
+  }
+};

--- a/api/notifications/gsa/user.create.welcome/template.html
+++ b/api/notifications/gsa/user.create.welcome/template.html
@@ -1,0 +1,15 @@
+<p>Hello<% if (user.name) { %> <%- user.name %><% } %>,</p>
+
+<p>Welcome to <%= globals.systemName %>! As a participant, you’ll be able to collaborate with people across different agencies and complete projects that reflect your interests.</p>
+
+<p>Before you start expressing interest in opportunities, please complete your <a href="<%- globals.urlPrefix %>/profile">profile</a>:<p>
+
+<p>Write your bio: Share a bit of background information to help other participants get to know you.<p>
+<p>Add a photo: Upload a profile picture to help other participants put a face to your name.<p>
+<p>List skills and topics: List your strongest skills and topics that interest you - this helps task creators match you with your ideal Opportunities.<p>
+
+<p>
+  We’re happy to have you involved!
+  <br/>
+  - The <%= globals.systemName %> Team
+</p>

--- a/api/notifications/gsa/userpasswordreset.create.token/notification.js
+++ b/api/notifications/gsa/userpasswordreset.create.token/notification.js
@@ -1,0 +1,25 @@
+module.exports = {
+
+  subject: 'Reset your password on <%- globals.systemName %>',
+
+  to: '<%= user.username %>',
+
+  /*
+  * Prepares the data object to render templates
+  * @param {Notification} notification model
+  * @param {function} callback called with err, data
+  * data.globals defaults to sails.config
+  */
+  data: function(model, done) {
+    var data = {
+          user: {},
+          link: '/profile/reset/' + model.token
+        };
+
+    User.findOne({ id: model.userId }).exec(function(err, user) {
+      if (err) return done(err);
+      data.user = user;
+      done(null, data);
+    });
+  }
+};

--- a/api/notifications/gsa/userpasswordreset.create.token/template.html
+++ b/api/notifications/gsa/userpasswordreset.create.token/template.html
@@ -1,0 +1,20 @@
+<p>Hello<% if (user.name) { %> <%- user.name %><% } %>,</p>
+<p>Did you forget your password?  On <a href="<%- globals.urlPrefix %>"><%- globals.systemName %></a>, you recently
+  requested a new password.
+</p>
+<p>Click the link below, or copy and paste the following link into your browser in order to reset your password:
+</p>
+<p>
+  <a href="<%- globals.urlPrefix %><%- link %>"><%- globals.urlPrefix %><%- link %></a>
+</p>
+<p>
+  If you did not request a new password, do not worry.  You can just delete this email.
+</p>
+<p class="center full-width">
+  <a href="<%- globals.urlPrefix %><%- link %>" class="btn btn-c2" bgcolor="39B7EA">Reset Password</a>
+</p>
+<p>
+  Thanks!
+  <br/>
+  - The <%- globals.systemName %> Team
+</p>

--- a/api/notifications/gsa/volunteer.create.thanks/notification.js
+++ b/api/notifications/gsa/volunteer.create.thanks/notification.js
@@ -1,0 +1,50 @@
+module.exports = {
+
+  subject: 'Thanks for your interest in <%= task.title %>',
+
+  to: '<%- user.username %>',
+
+  cc: '<%- owner.username %>',
+
+  /*
+  * Prepares the data object to render templates
+  * @param {Notification} notification model
+  * @param {function} callback called with err, data
+  * data.globals defaults to sails.config
+  */
+  data: function ( model, done ) {
+    var data = {
+      task: {},
+      owner: {},
+      user: {},
+    };
+
+    User.findOne( { id: model.userId } ).exec( function ( err, user ) {
+
+      if ( err ) { return done( err ); }
+
+      data.user = user;
+
+      Task.findOne( { id: model.task} ).exec( function ( err, task ) {
+
+        if ( err ) { return done( err ); }
+
+        data.task = task;
+
+        User.findOne( { id: task.owner } ).exec( function ( err, owner ) {
+
+          if ( err ) { return done( err ); }
+
+          data.owner = owner;
+
+          done( null, data );
+
+        } );
+
+      } );
+
+    } );
+
+  },
+
+};

--- a/api/notifications/gsa/volunteer.create.thanks/template.html
+++ b/api/notifications/gsa/volunteer.create.thanks/template.html
@@ -1,0 +1,32 @@
+<p>Dear <%- user.name %>,</p>
+
+<p>Thanks for your interest in <a href="<%- globals.urlPrefix %>/tasks/<%- task.id %>"><%- task.title %></a>! Your information has been forwarded to the opportunity point of contact for consideration.  You may be contacted for further information/screening if needed.</p>
+
+<p>Once a selection has been made, you will be notified of the final outcome.</p>
+
+
+<p>Thanks again,</p>
+
+<p>- The <%- globals.systemName %> Team</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/api/notifications/gsa/volunteer.destroy.decline/notification.js
+++ b/api/notifications/gsa/volunteer.destroy.decline/notification.js
@@ -1,0 +1,39 @@
+module.exports = {
+
+  subject: 'An update on <%- task.title %>',
+
+  to: '<%- user.username %>',
+
+  cc: '<%- owner.username %>',
+
+  /*
+  * Prepares the data object to render templates
+  * @param {Notification} notification model
+  * @param {function} callback called with err, data
+  * data.globals defaults to sails.config
+  */
+  data: function(model, done) {
+    var data = {
+          task: {},
+          user: {},
+          owner: {}
+        };
+
+    User.findOne({ id: model.userId }).exec(function(err, user) {
+      if (err) return done(err);
+      data.user = user;
+
+      Task.findOne({ id: model.taskId }).exec(function(err, task) {
+        if (err) return done(err);
+        data.task = task;
+
+        User.findOne({ id: task.owner }).exec(function(err, owner) {
+          if (err) return done(err);
+          data.owner = owner;
+          done(null, data);
+        });
+      });
+
+    });
+  }
+};

--- a/api/notifications/gsa/volunteer.destroy.decline/template.html
+++ b/api/notifications/gsa/volunteer.destroy.decline/template.html
@@ -1,0 +1,9 @@
+<p>Hi <%- user.name %>,</p>
+
+<p>Thank you for your interest. Your application for <%- task.title %> was not selected but we hope that you will consider applying to other opportunities in the future.  To see a selection of currently available opportunities, please <a href='<%- globals.urlPrefix %>/tasks'>click here</a>.</p>
+
+<p>Once again, thanks for your interest in this Opportunity. If you have any questions, please don’t hesitate to reach out.</p>
+
+<p>Have a great day,</p>
+
+<p>- The <%- globals.systemName %> Team</p>


### PR DESCRIPTION
Starting with GSA. This patch series introduces the concept of _scoped_ notifications. Because all notifications are based on events and those events map to files on the file-system, we can easily add agencies by scoping them within their `slug` directory.

For example, default notifications live in `api/notifications/*` while scoped notifications live one folder deeper identified by their agency's `slug`, `api/notifications/<agency_slug>/*`.
#### Acceptance Criteria
- [ ] Notifications can be customized at the agency level.
- [ ] Custom notifications take precedence over default notifications.
- [ ] If no custom notification is found, a default notification is sent.
