### PR TITLE
Update where session.secret is coming from

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -251,7 +251,7 @@ Here's an example using `export`:
 [openopps_theme_repo]: https://github.com/18F/open-opportunities-theme "Open Opportunities Theme"
 
 Note: the tests don't currently pass when the theme is installed since it
-also changes configuration.  
+also changes configuration.
 
 #### Clone the git repository.
 
@@ -304,6 +304,7 @@ Run the tests (all should pass)
 
 Run the server (watch client files, compiling if needed)
 
+    export SAILS_SECRET='RANDOM_BITS_FOR_SAILS_SESSIONS_ID'
     npm run watch
 
 

--- a/config/session.js
+++ b/config/session.js
@@ -20,7 +20,7 @@ var session = {
   // Session secret is automatically generated when your new app is created
   // Replace at your own risk in production-- you will invalidate the cookies of your users,
   // forcing them to log in again.
-  secret: '0fa32505a53e70cd2b5626d70dd15b6c',
+  secret: process.env.SAILS_SECRET,
 
   // Set the cookie maximum age (timeout).  If this is not set, then cookies
   // will persist forever.


### PR DESCRIPTION
This PR gets the session.secret from the environment rather than having it hard-coded in the application. It's okay to have it in the code, but this will allow us to invalidate all sessions by just updating the user-provided-service.