### PR TITLE
[WIP] Add preliminary docker-compose support.

### DIFF
--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -1,0 +1,4 @@
+FROM node:6.10.1
+
+RUN apt-get update && \
+  apt-get install -y postgresql-client graphicsmagick

--- a/api/models/Notification.js
+++ b/api/models/Notification.js
@@ -10,6 +10,15 @@
      protocol = sails.config.emailProtocol,
      transportConfig = sails.config[protocol.toLowerCase()];
 
+if (protocol == '') {
+  // We're running tests, just use nodemailer's stream transport.
+  transportConfig = {
+    streamTransport: true,
+    newline: 'unix',
+    buffer: true
+  };
+}
+
 module.exports = {
 
   attributes: {

--- a/assets/js/backbone/apps-router.js
+++ b/assets/js/backbone/apps-router.js
@@ -18,7 +18,11 @@ var initialize = function() {
   var i18nConfig = JSON.parse(i18nConfigJSON);
   i18n.use(XHR)
     .init(i18nConfig, function(err, t) {
-      i18nextJquery.default.init(i18n, $);
+      // TODO: Not sure if older version of jquery-i18next was
+      // used previously, but it seems the version of it
+      // on my system doesn't have a 'default' property--
+      // 'init' is directly a property of the object itself. -AV
+      (i18nextJquery.default || i18nextJquery).init(i18n, $);
 
       // Here we are going to fire up all the routers for our app to listen
       // in on their respective applications.  We are -testing- this functionality

--- a/config/connections.js
+++ b/config/connections.js
@@ -67,4 +67,21 @@ if (dbURL) {
   module.exports.models = {
     connection: 'postgresql'
   };
+
+  // It looks like the code expects development instances to
+  // not define a DATABASE_URL--or at least, if one is
+  // defined, we get a mysterious "A hook (`orm`) failed to load!"
+  // error w/ no traceback when running 'grunt db:migrate:up'.
+  //
+  // However, we need to use DATABASE_URL under docker, and
+  // the following code seems to make things work similarly to
+  // the way things work when DATABASE_URL isn't defined, as
+  // far as I can tell. Sails is confusing me. -AV
+
+  if (process.env.RUNNING_IN_DOCKER_FOR_DEVELOPMENT) {
+    module.exports.connections['local'] = {
+      adapter: 'sails-disk'
+    };
+    module.exports.models.connection = 'local';
+  }
 }

--- a/config/connections.js
+++ b/config/connections.js
@@ -67,21 +67,4 @@ if (dbURL) {
   module.exports.models = {
     connection: 'postgresql'
   };
-
-  // It looks like the code expects development instances to
-  // not define a DATABASE_URL--or at least, if one is
-  // defined, we get a mysterious "A hook (`orm`) failed to load!"
-  // error w/ no traceback when running 'grunt db:migrate:up'.
-  //
-  // However, we need to use DATABASE_URL under docker, and
-  // the following code seems to make things work similarly to
-  // the way things work when DATABASE_URL isn't defined, as
-  // far as I can tell. Sails is confusing me. -AV
-
-  if (process.env.RUNNING_IN_DOCKER_FOR_DEVELOPMENT) {
-    module.exports.connections['local'] = {
-      adapter: 'sails-disk'
-    };
-    module.exports.models.connection = 'local';
-  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,12 +16,11 @@ services:
     environment:
       - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/app/node_modules/.bin
       - DATABASE_URL=postgres://midas@db/midas
-      - DATASTORE=local
+      - DATASTORE=postgresql
       - LOG_LEVEL=silly
       - PORT=3000
       - SAILS_SECRET=just_for_testing_yo
       - 'VCAP_APPLICATION={ "uris": [ "openopps-test.18f.gov" ] }'
-      - RUNNING_IN_DOCKER_FOR_DEVELOPMENT=yup
   db:
     image: postgres:9.3
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '2'
+services:
+  app:
+    build:
+      dockerfile: Dockerfile.simple
+      context: .
+    volumes:
+      - .:/app
+      - node-modules:/app/node_modules/
+    working_dir: /app
+    command: npm run watch
+    ports:
+      - 3000:3000
+    links:
+      - db
+    environment:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/app/node_modules/.bin
+      - DATABASE_URL=postgres://midas@db/midas
+      - DATASTORE=local
+      - LOG_LEVEL=silly
+      - PORT=3000
+      - SAILS_SECRET=just_for_testing_yo
+      - 'VCAP_APPLICATION={ "uris": [ "openopps-test.18f.gov" ] }'
+      - RUNNING_IN_DOCKER_FOR_DEVELOPMENT=yup
+  db:
+    image: postgres:9.3
+    volumes:
+      - pgdata:/var/lib/postgresql/data/
+    environment:
+      - POSTGRES_DB=midas
+      - POSTGRES_USER=midas
+volumes:
+  node-modules:
+  pgdata:


### PR DESCRIPTION
Note that this PR is against #1499, since that seems to be the latest branch right now.

## Instructions

* Run `docker-compose up db` and wait until you see the log message `PostgreSQL init process complete`.  This means that the database has been created.  Then press ctrl-c.
* Run `docker-compose run app npm install --unsafe-perm`.  The `--unsafe-perm` is needed because you're running some startup scripts as root in the container, which `npm` doesn't like. We can fix that in a later PR though.
* Run `docker-compose run app npm run init`.
* Run `docker-compose up` to start everything and visit http://localhost:3000/.

## Notes

* The docs claim postgres 9.2 is required, but some scripts use features introduced in 9.3.
* The docs are very confusing about what version of node is required, so I just used what was specified in `package.json`.

## To do

- [ ] Add setup instructions
- [x] Make sure tests run in the container
