### PR TITLE
link to this repo (instead of 18F)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Open Opportunities can benefit all organizations, but it’s especially useful f
 * Use our [community test server](https://openopps-test.18f.gov) and write up [issues](https://github.com/openopps/openopps-platform/issues)
 * Join our [Google Group](https://groups.google.com/forum/#!forum/openopps-platform) and introduce yourself, please ask any general questions here -- how the product is supposed to work, usability issues, technical questions, whatever you want to know, we want to hear about.  If you are interested in using Open Opportunities for your organization, let us know.
 * Read our [Contribution Guide][contributing] -- everything you do with us is a contribution to the public domain, there are also some tips for getting started
-* If you are a developer, [install](https://github.com/18F/openopps-platform/blob/dev/INSTALL.md) the software for development
-* Dive into our [help wanted issues](https://github.com/18F/openopps-platform/labels/help%20wanted) -- there are both dev and design opportunities there
+* If you are a developer, [install](INSTALL.md) the software for development
+* Dive into our [help wanted issues](https://github.com/openopps/openopps-platform/labels/help%20wanted) -- there are both dev and design opportunities there
 
 ## More Project Details
 
@@ -79,6 +79,6 @@ This project is in the public domain within the United States, and
 copyright and related rights in the work worldwide are waived through
 the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 
-For more information, see [license](https://github.com/18F/openopps-platform/blob/dev/LICENSE.md).
+For more information, see [license](LICENSE.md).
 
-[contributing]: https://github.com/18F/openopps-platform/blob/dev/CONTRIBUTING.md
+[contributing]: CONTRIBUTING.md


### PR DESCRIPTION
used relative links for most places
couldn't figure out how to make a relative link to issues, so those are fully qualified to refer to this repo