### PR TITLE
fix URL references to refer to openopps repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,9 +134,9 @@
   "main": "app.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/18F/openopps-platform.git"
+    "url": "https://github.com/openopps/openopps-platform.git"
   },
-  "bugs": "https://github.com/18F/openopps-platform/issues",
+  "bugs": "https://github.com/openopps/openopps-platform/issues",
   "license": "CC0-1.0",
   "engines": {
     "node": "6.11.1",


### PR DESCRIPTION
main repo used to be at 18F, now that one is a fork of this one
so URLs should refer to https://github.com/openopps