### PR TITLE
fixing code-of-conduct link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,9 @@
 ## Contributing
 
-We aspire to create a welcoming environment for collaboration on this project.
-To that end, we follow the [18F Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md) and ask that all contributors do the same. Open Opps has a defined [governance model](GOVERNANCE.md) to assist with managing the project.  
+We aspire to create a welcoming environment for collaboration on this project.  To that end, we follow the [Code for America Code of Conduct](https://github.com/codeforamerica/codeofconduct) and ask that all contributors do the same. 
+
+Note: Open Opps has a defined [governance model](GOVERNANCE.md) to assist with managing the project.  
+
 ### Public domain
 
 This project is in the public domain within the United States, and


### PR DESCRIPTION
moving to CfA code-of-conduct since 18F link is broken
addressed issue #1521