### PR TITLE
Update mac install with dbmigrate command..

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -237,6 +237,7 @@ See the [Configuration Guide](CONFIG.md)
 
 From the root of the openopps directory, initialize the database:
 
+     npm run migrate:up
      npm run init
 
 If you'd like to include a sample project and users, also run:

--- a/tools/demo.js
+++ b/tools/demo.js
@@ -10,7 +10,8 @@ dbTools.checkTableSetup('midas_user').then(async () => {
 }).then(function (tasks) {
   //console.log('new tasks created: ', tasks);
 }).then(() => {
-    console.log("Completed successfully. Ctrl-C to return to terminal.");        
+  console.log("Completed successfully.");
+  process.exit();
 }).catch(function (err) {
   console.log('err: ', err);
 });

--- a/tools/demo.js
+++ b/tools/demo.js
@@ -9,6 +9,8 @@ dbTools.checkTableSetup('midas_user').then(async () => {
   return dbTools.importTasksFromFile(path.join(dataDir, 'tasks.csv'));
 }).then(function (tasks) {
   //console.log('new tasks created: ', tasks);
+}).then(() => {
+    console.log("Completed successfully. Ctrl-C to return to terminal.");        
 }).catch(function (err) {
   console.log('err: ', err);
 });

--- a/tools/init.js
+++ b/tools/init.js
@@ -26,6 +26,8 @@ dbTools.checkTagTableSetup()
     }, function(err) { // eachSeries completed
       if (err) {
         console.log("Failed with error: ", err);
+      } else {
+        console.log("Completed successfully. Ctrl-C to return to terminal.");        
       }
       dbTools.end();
     });

--- a/tools/init.js
+++ b/tools/init.js
@@ -27,7 +27,8 @@ dbTools.checkTagTableSetup()
       if (err) {
         console.log("Failed with error: ", err);
       } else {
-        console.log("Completed successfully. Ctrl-C to return to terminal.");        
+        console.log("Completed successfully.");
+        process.exit();
       }
       dbTools.end();
     });


### PR DESCRIPTION
I tested install instructions starting from no database, and realized we were missing the db migrate command.

Also, added some instructions that we need to "ctrl-c" after the init and demo scripts, since I thought that might be helpful for new folks.