### PR TITLE
Fix viewing shared profile from email link bug.

### DIFF
--- a/api/auth/auth.js
+++ b/api/auth/auth.js
@@ -1,7 +1,12 @@
 const _ = require ('lodash');
 
 async function baseAuth (ctx, next) {
-  ctx.isAuthenticated() ? await next() : ctx.status = 401;
+  if(ctx.isAuthenticated()) {
+    await next();
+  } else {
+    ctx.body = { message: 'You must be logged in to view this page' };
+    ctx.status = 401;
+  }
 }
 
 module.exports = baseAuth;

--- a/assets/js/backbone/apps/profiles/show/controllers/profile_show_controller.js
+++ b/assets/js/backbone/apps/profiles/show/controllers/profile_show_controller.js
@@ -94,7 +94,7 @@ var Profile = BaseController.extend({
     // not being logged in
     this.listenTo(this.model, 'profile:fetch:error', function (model, response) {
       // if the user isn't logged in, trigger the login window
-      if (response.status === 403) {
+      if (response.status === 401 || response.status === 403) {
         window.cache.userEvents.trigger('user:request:login', {
           message: 'You must be logged in to view profiles',
           disableClose: false,


### PR DESCRIPTION
Check for 401 and prompt user to log in if not already in order to view
profiles.

Create JSON message for 401 to display on login modal that user must log
in to view this page.