### PR TITLE
Session expiration warning. 

### DIFF
--- a/assets/js/backbone/apps/nav/views/nav_view.js
+++ b/assets/js/backbone/apps/nav/views/nav_view.js
@@ -42,7 +42,10 @@ var NavView = Backbone.View.extend({
     // request that the user log in to see the page
     this.listenTo(window.cache.userEvents, 'user:request:login', function (message) {
       // trigger the login modal
-      self.login(message);
+      $.getJSON('/csrfToken', function (t) {
+        $('meta[name="csrf-token"]').attr('content', t._csrf);
+        self.login(message);
+      });
     });
 
     // update the navbar when the profile changes

--- a/assets/js/backbone/browse-app.js
+++ b/assets/js/backbone/browse-app.js
@@ -53,6 +53,7 @@ var BrowseRouter = Backbone.Router.extend({
         .closest('li')
         .addClass('active');
       $.getJSON('/csrfToken', function (t) {
+        window.cache.userEvents.trigger('idle:reset');
         $('meta[name="csrf-token"]').attr('content', t._csrf);
         $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
           var token;

--- a/assets/js/backbone/components/modal_idle.js
+++ b/assets/js/backbone/components/modal_idle.js
@@ -1,0 +1,84 @@
+// Idle Modal component
+// This component will notify the user of a pending session expiration.
+// There are two JS timeouts. The first is when should we display the
+//    modal to the user, and the second is how long after displaying
+//    the modal do we force a logout.
+var $ = require('jquery');
+var _ = require('underscore');
+var Backbone = require('backbone');
+var BaseComponent = require('../base/base_component');
+var ModalIdleTemplate = require('./modal_idle_template.html');
+
+var ModalIdle = BaseComponent.extend({
+  events: {
+    'click .idle-reset'  : 'resetTimeout',
+    'click .idle-logout' : 'logout',
+  },
+
+  initialize: function (options) {
+    var self = this;
+    this.options = options;
+    this.keyPressCount = 0;
+    this.timeSinceLastKeyPress = 0;
+    this.data = {
+      id: 'modal-idle',
+      modalTitle: 'Your Session is About to Expire!',
+    };
+    this.initializeListeners();
+  },
+
+  initializeListeners: function () {
+    var self = this;
+    this.listenTo(window.cache.userEvents, 'idle:reset', function () {
+      self.resetTimeout();
+    });
+    document.onkeyup   = self.keyPressCheck.bind(this);
+    document.onkeydown = self.keyPressCheck.bind(this);
+  },
+
+  render: function () {
+    var compiledTemplate = _.template(ModalIdleTemplate)(this.data);
+    this.$el.html(compiledTemplate);
+    return this;
+  },
+
+  cleanup: function () {
+    removeView(this);
+  },
+
+  keyPressCheck: function () {
+    var d = new Date();
+    var now = d.getTime();
+    if (this.keyPressCount >= 30 || (now - this.timeSinceLastKeyPress) > 60 * 1000) {
+      this.resetTimeout();
+      this.keyPressCount = 0;
+    } else {
+      this.keyPressCount++;
+    }
+    this.timeSinceLastKeyPress = now;
+  },
+
+  resetTimeout: function () {
+    $.getJSON('/csrfToken', function (t) {
+      $('meta[name="csrf-token"]').attr('content', t._csrf);
+      if(this.timeoutID) clearTimeout(this.timeoutID);
+      if(this.warningID) clearTimeout(this.warningID);
+      this.timeoutID = setTimeout(function () {
+        this.warningID = setTimeout(function () {
+          this.logout();
+        }.bind(this), 3 * 60 * 1000); // Logout after 3 minutes
+        $('#' + this.data.id).modal('show');
+      }.bind(this), 27 * 60 * 1000); // 27 minutes then show 3 minute warning
+      $('#' + this.data.id).modal('hide');
+    }.bind(this));
+  },
+
+  logout: function () {
+    $('#' + this.data.id).modal('hide');
+    setTimeout(function () {
+      window.cache.userEvents.trigger('user:request:logout');
+    }, 500);
+  },
+});
+
+module.exports = ModalIdle;

--- a/assets/js/backbone/components/modal_idle_template.html
+++ b/assets/js/backbone/components/modal_idle_template.html
@@ -1,0 +1,28 @@
+<div class="modal fade" id="<%- id %>" role="dialog" aria-hidden="true" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+
+      <div class="modal-header">
+        <h4 class="modal-title"><%- modalTitle %></h4>
+      </div>
+
+      <div class="modal-body">
+        <p>
+          Your Open Opportunities session will expire due to inactivity in three minutes.
+          Any unsaved data will be lost if you allow the session to expire.
+          Click the button below to continue your session.
+        </p>
+      </div>
+
+      <div class="modal-footer modal-footer-grey">
+        <button type="button" id="idle-logout-button" class="btn btn-c2 idle-logout">
+          Logoff
+        </button>
+        <button type="button" id="idle-reset-button" class="btn btn-c2 idle-reset">
+          Stay Logged In
+        </button>
+      </div>
+
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div>

--- a/config/session.js
+++ b/config/session.js
@@ -21,7 +21,7 @@ var session = {
    * This is different from cookie.maxAge, setting
    * this to null to get ttl from cookie.maxAge.
    */
-  ttl: 15 * 60 * 1000, // 15 minutes
+  ttl: 35 * 60 * 1000, // 35 minutes
 
   /* Force a session identifier cookie to be set on every response.
    * The expiration is reset to the original maxAge, resetting the


### PR DESCRIPTION
Added an idle modal that alert the user that due to inactivity they will
be logged out. The warning give the user a three minute window in which
to reset his/her session. Sessions are currently set for 30 minutes,
therefore the user will be alerted after 27 minutes of inactivity.

Reset session timer on page navigation. Reset session timer on 30
keypresses or one minute lapse in time since last keypress.

#1645 