### PR TITLE
Require a federal email address

### DIFF
--- a/assets/js/backbone/apps/login/views/login_create_view.js
+++ b/assets/js/backbone/apps/login/views/login_create_view.js
@@ -136,8 +136,9 @@ var LoginCreateView = Backbone.View.extend({
         url: '/api/user',
         dataType: 'json',
       }).done(function (data) {
-        self.$('#registration-complete').show();
+        $('#registration-error').hide();
         self.$('#main-content').hide();
+        self.$('#registration-complete').show();
       });
     }).fail(function (error) {
       var d = JSON.parse(error.responseText);


### PR DESCRIPTION
- Fix issue where after user corrects validation errors and submits
new account creation successfully the error alert still displays
along with the success alert

#1849