### PR TITLE
removing submitted and draft from search if not admin

### DIFF
--- a/assets/js/backbone/apps/tasks/search/templates/internship_search_item.html
+++ b/assets/js/backbone/apps/tasks/search/templates/internship_search_item.html
@@ -88,7 +88,7 @@
               <p class="usajobs-open-opps-opportunity-requestor__name">
                 <!-- <%- item.owner.name %> <% if (item.owner.agency && item.owner.agency.abbr) { %>(<%- item.owner.agency.abbr %>)<% } %> -->
                 <% if (item.community.shortName == 'Student Internship Program (Unpaid)') { %>
-                  Department of State
+                  U.S. Department of State
                 <% } else { %>
                   <%- item.postingAgency %>
                 <% } %>

--- a/elastic/service.js
+++ b/elastic/service.js
@@ -98,6 +98,7 @@ service.convertQueryStringToOpportunitiesSearchRequest = function (ctx, index){
     }
   };
   var filter_must = request.body.query.bool.filter.bool.must;
+  var filter_must_not = request.body.query.bool.filter.bool.must_not;
   var should_match = request.body.query.bool.should;
   var formatParamTypes = ["skill", "career", "series", "location", "keywords", "language", "agency", "program"];
 
@@ -150,6 +151,10 @@ service.convertQueryStringToOpportunitiesSearchRequest = function (ctx, index){
   }
   if (agencies.length > 0) {
     request.addTerms(agencies, 'restrictedToAgency');
+  }
+
+  if (!ctx.state.user || !ctx.state.user.isAdmin) {
+    filter_must_not.push({terms: { ['state'] : ['submitted', 'draft'] }});
   }
 
   var keywords = []


### PR DESCRIPTION
Updating search to not show draft and submitted tasks if the user is not an admin. Also updated the search card display to show U.S. Department of State instead of just department of state.

#2708 