### PR TITLE
x-authorization header code. Authorization header is being blocked.

### DIFF
--- a/api/auth/passport.js
+++ b/api/auth/passport.js
@@ -229,7 +229,7 @@ if (openopps.auth.oidc) {
   };
 
   var opts = {};
-  opts.jwtFromRequest = ExtractJwt.fromAuthHeaderAsBearerToken();
+  opts.jwtFromRequest = ExtractJwt.fromExtractors([ExtractJwt.fromAuthHeaderAsBearerToken(), ExtractJwt.fromHeader("x-authorization")]);
   opts.secretOrKeyProvider = passportJwtSecret({
     cache: true,
     rateLimit: true,


### PR DESCRIPTION
Added an x-authorization header as the standard authorization header is being blocked.