### PR TITLE
Bug: Internship skills should search against internship page

### DIFF
--- a/assets/js/backbone/apps/internships/show/templates/internship_view.html
+++ b/assets/js/backbone/apps/internships/show/templates/internship_view.html
@@ -27,7 +27,7 @@
             <div class="skills">
               <div>Desired skills:</div>
               <% _.each(madlibTags['skill'], function (t) { %>
-                <a class="skill-label" href="/tasks?search=<%= t.name %>"><%= t.name %></a>
+                <a class="skill-label" href="/search/internships?skill=<%= t.name %>"><%= t.name %></a>
               <% }) %>
             </div>
           </div>


### PR DESCRIPTION
- Fix url to internship search page  for issue selecting "skills" from internship view page

#3287