### PR TITLE
Add logic to remove duplicate government URI on login

### DIFF
--- a/api/auth/dao.js
+++ b/api/auth/dao.js
@@ -8,6 +8,11 @@ const userQuery = 'select @m_user.*, @agency.*, @tags.* ' +
   'left join @agency on agency.agency_id = m_user.agency_id ' +
   'where m_user.disabled = false and m_user.id = ?';
 
+const userUpdateQuery = 'update midas_user set ' +
+  'government_uri = \'\' ' +
+  'where linked_id != ? and government_uri = ?';
+
+
 const tagEntityQuery = 'select tagentity_users__user_tags.* ' +
   'from tagentity_users__user_tags ' +
   'join tagentity on tagentity.id = tagentity_users ' +
@@ -57,6 +62,7 @@ module.exports = function (db) {
     query: {
       user: userQuery,
       tagEntity: tagEntityQuery,
+      updateUser: userUpdateQuery,
     },
     options: options,
     clean: clean,

--- a/api/auth/passport.js
+++ b/api/auth/passport.js
@@ -62,6 +62,12 @@ async function userFound (user, tokenset, done) {
   }
 }
 
+function removeDuplicateFederalURI (tokenset) {
+  dao.User.query(dao.query.updateUser, tokenset.claims.sub, tokenset.claims['usaj:governmentURI']).catch(() => {
+    var i = 1;
+  });
+}
+
 function processFederalEmployeeLogin (tokenset, done) {
   dao.User.findOne('linked_id = ? or (linked_id = \'\' and username = ?)', tokenset.claims.sub, tokenset.claims['usaj:governmentURI']).then(user => {
     userFound(user, tokenset, done);
@@ -179,6 +185,9 @@ if (openopps.auth.oidc) {
     },
   };
   passport.use('oidc', new Strategy(OpenIDStrategyOptions, (tokenset, userinfo, done) => {
+    if (tokenset.claims['usaj:governmentURI']) {
+      removeDuplicateFederalURI(tokenset);
+    }
     if (tokenset.claims['usaj:hiringPath'] == 'fed' && tokenset.claims['usaj:governmentURI']) {
       processFederalEmployeeLogin(tokenset, done);
     } else if (tokenset.claims['usaj:hiringPath'] == 'student') {

--- a/api/auth/passport.js
+++ b/api/auth/passport.js
@@ -66,9 +66,7 @@ async function userFound (user, tokenset, done) {
 }
 
 function removeDuplicateFederalURI (tokenset) {
-  dao.User.query(dao.query.updateUser, tokenset.claims.sub, tokenset.claims['usaj:governmentURI']).catch(() => {
-    var i = 1;
-  });
+  dao.User.query(dao.query.updateUser, tokenset.claims.sub, tokenset.claims['usaj:governmentURI']);
 }
 
 function processFederalEmployeeLogin (tokenset, done) {


### PR DESCRIPTION
Adding logic to remove duplicate government URIs from other accounts when logging in with an account that has a government URI. 

There is no equivalent github ticket so not able to connect with an issue.