### PR TITLE
Unsupported date format for Safari and Firefox

### DIFF
--- a/assets/js/backbone/apps/profiles/home/internships/templates/internships_applied_template.html
+++ b/assets/js/backbone/apps/profiles/home/internships/templates/internships_applied_template.html
@@ -42,7 +42,7 @@
                     <%= getStatus(d) %>
                   </td>
                   <td class="application-program-title">
-                    <% var today = new Date(moment().tz("America/New_York").format('MM-DD-YYYY')); if (new Date(d.applyEndDate) >= today) { %>
+                    <% var today = new Date(moment().tz("America/New_York").format('MM/DD/YYYY')); if (new Date(d.applyEndDate) >= today) { %>
                       <a href="/apply/<%- d.id %>" class="activity-link" data-id="<%- d.id %>"><%- d.communityName %></a>
                     <% } else { %>
                       <%- d.communityName %>

--- a/assets/js/backbone/apps/tasks/search/views/internship_search_view.js
+++ b/assets/js/backbone/apps/tasks/search/views/internship_search_view.js
@@ -159,7 +159,7 @@ var InternshipListView = Backbone.View.extend({
           var cycleStartDate = new Date(data[i].cycleStartDate);
           var startDate = new Date(data[i].applyStartDate);
           var endDate = new Date(data[i].applyEndDate);
-          var today = new Date(moment().tz('America/New_York').format('MM-DD-YYYY'));
+          var today = new Date(moment().tz('America/New_York').format('MM/DD/YYYY'));
           if (!(communityId in this.cycles)) {
             this.cycles[communityId] = [];
             this.futureCycles[communityId] = [];


### PR DESCRIPTION
- Update date format to use "/" instead of "-" since Safari and Firefox
do not support this syntax for date formats

#3561