### PR TITLE
Sitewide: Help links don't open in new window

### DIFF
--- a/assets/js/backbone/apps/nav/templates/nav_template.html
+++ b/assets/js/backbone/apps/nav/templates/nav_template.html
@@ -48,7 +48,7 @@
               <% } %>
             <% } %>
             <li class="usajobs-nav__menu-container usajobs-nav__menu-search desktop">
-                <a class="usajobs-nav__section-link usajobs-nav--openopps__section-link" href="https://usajobs.github.io/openopps-help/" title="Help">
+                <a class="usajobs-nav__section-link usajobs-nav--openopps__section-link" href="https://usajobs.github.io/openopps-help/"  target="_blank" rel="noopener noreferrer" title="Help">
                   <span class="usajobs-nav--openopps__section">
                     <span class="fas fa-question-circle" title="Help"></span>Help
                   </span>


### PR DESCRIPTION
- redirect help link to new window

#2853