### PR TITLE
Adding primary phase started email

### DIFF
--- a/api/notification/state.department/firstphase.start.confirmation/template.html
+++ b/api/notification/state.department/firstphase.start.confirmation/template.html
@@ -1,0 +1,19 @@
+<p>Hello <% if (user.name) { %><%- user.name %><% } %>,</p>
+
+<p>The primary phase of the applicant review process, for the U.S. Department of State Student Internship Program (Unpaid), has started. 
+  Hiring managers can now see their applicant review boards and select their primary interns. They have two weeks to complete this phase.</p>
+
+<p style="font-weight:bold">What happens next?</p>
+
+<p>In <span style="font-weight:bold">two weeks</span> you need to <a href="<%- agencyportallink %>">sign back into the Agency Talent Portal</a> 
+  and start the alternate phase for the U.S. Department of State Student Internship Program (Unpaid).</p>
+
+<p><a href="<%- alternatephaselink %>">Sign in to start the alternate phase</a></p>
+
+<p>
+  <ul>
+    <li>boards populated with applicants: <%- boardspopulated %></li>
+    <li>emails sent to community members: <%- emailsqueued %></li>
+  </ul>
+</p>
+

--- a/api/notification/state.department/firstphase.start.confirmation/template.js
+++ b/api/notification/state.department/firstphase.start.confirmation/template.js
@@ -1,0 +1,14 @@
+module.exports = {
+  subject: 'U.S. Department of State Student Internship Program (Unpaid) – The primary phase has started',
+  to: '<%= user.username %>',
+  data: function (model, done) {
+    var data = {
+      user: model.user,
+      alternatephaselink: model.alternatephaselink,
+      agencyportallink: model.agencyportallink,
+      boardspopulated: model.boardspopulated,
+      emailsqueued: model.emailsqueued,
+    };
+    done(null, data);
+  },
+};

--- a/api/v1/cycle/controller.js
+++ b/api/v1/cycle/controller.js
@@ -33,8 +33,10 @@ Handler.startPrimaryPhase = async function (ctx) {
   await service.startPhaseProcessing(ctx.request.fields.cycleId);
   return new Promise((resolve, reject) => {
     drawMany(ctx).then(results => {
+      service.sendPrimaryPhaseStartedNotification(ctx.state.user, true);
       resolve(results);
     }).catch(err => {
+      service.sendPrimaryPhaseStartedNotification(ctx.state.user, false);
       reject(err);
     });
   });

--- a/api/v1/cycle/service.js
+++ b/api/v1/cycle/service.js
@@ -2,6 +2,7 @@ const db = require('../../../db');
 const dao = require('./dao')(db);
 var _ = require('lodash');
 const Audit = require('../../model/Audit');
+const notification = require('../../notification/service');
 
 var service = {};
 
@@ -93,6 +94,20 @@ service.createAuditLog = async function (type, ctx, auditData) {
 
 service.recordError = async function (userId, err) {
   dao.ErrorLog.insert({ userId: userId, errorData: err }).catch();
+};
+
+service.sendPrimaryPhaseStartedNotification = async function (user, boardsPopulated) {
+  var data = {
+    action: 'state.department/firstphase.start.confirmation',
+    model: {
+      user: user,
+      agencyportallink: process.env.AGENCYPORTAL_URL,
+      alternatephaselink: process.env.AGENCYPORTAL_URL + '/review',
+      boardspopulated: boardsPopulated ? 'success' : 'fail',
+      emailsqueued: 'success',
+    },
+  };
+  notification.createNotification(data);
 };
 
 function getNextInternshipIndex (internshipIndex) {

--- a/config/application.js
+++ b/config/application.js
@@ -12,7 +12,8 @@ module.exports = {
   hostName: process.env.HOST || 'localhost:3000',
 
   usajobsURL: process.env.USAJOBS_URL || 'https://www.usajobs.gov',
-
+  
+  agencyportalURL: process.env.AGENCYPORTAL_URL || 'https://agencyportal.usajobs.gov',
   // redirect domain not matching hostName
   redirect: (process.env.REDIRECT || '').match(/^true$/i) || false,
 

--- a/environment.json
+++ b/environment.json
@@ -35,5 +35,6 @@
     "SYSTEM_NAME": "Open Opportunities",
     "TASK_STATE": "draft",
     "USAJOBS_URL": "https://www.usajobs.gov",
+    "AGENCYPORTAL_URL": "https://localhost:44373",
     "VALIDATE_DOMAINS": true
 }


### PR DESCRIPTION
Adding primary phase started email once a user starts the primary phase. The email will contain a status on whether the emails were queued and whether the boards were populated.

TFS ticket number 37488