### PR TITLE
Don't send opps back to submit status when edited

### DIFF
--- a/api/opportunity/service.js
+++ b/api/opportunity/service.js
@@ -300,6 +300,7 @@ async function updateOpportunity (ctx, attributes, done) {
   }
   var origTask = await dao.Task.findOne('id = ?', attributes.id);
   var tags = attributes.tags || attributes['tags[]'] || [];
+  attributes.communityId = attributes.communityId == '' ? null : attributes.communityId;
   if ((origTask.communityId != attributes.communityId) && attributes.state !=='draft') {  
     attributes.state = 'submitted';
     attributes.submittedAt = null;


### PR DESCRIPTION
- Prevent opportunities going to submit status when changing location

#4284